### PR TITLE
fix prebuild shellcheck tests to run properly with external sources

### DIFF
--- a/scripts/tests/prebuild/002-usrlocalbin.sh
+++ b/scripts/tests/prebuild/002-usrlocalbin.sh
@@ -71,7 +71,7 @@ do
     if [ "$SHELLCHECKNOTEXISTS" = "1" ]; then
       juLog -name="usrlocalbin_$(basename "$file")" false # Consider test failed if we don't have shellcheck
     else
-      juLog -name="usrlocalbin_$(basename "$file")" shellcheck "$file"
+      juLog -name="usrlocalbin_$(basename "$file")" shellcheck -x "$file"
     fi
   continue # Next file please
   fi


### PR DESCRIPTION
eliminates failure of shellcheck.  Was getting errors like:
In /opt/aredn/aredn_ar71xx/files/usr/local/bin/get_boardid line 6:
  . /lib/functions.sh
  ^-- SC1091: Not following: /lib/functions.sh was not specified as input (see shellcheck -x).