### PR TITLE
bugfix: sysupgrade no longer supports -d option

### DIFF
--- a/files/usr/local/bin/spawn_sysupgrade
+++ b/files/usr/local/bin/spawn_sysupgrade
@@ -7,6 +7,7 @@ then
 fi
 
 
-/sbin/sysupgrade -d 7 -f /tmp/arednsysupgradebackup.tgz -q "$1" 2>&1
+sleep 7
+/sbin/sysupgrade -f /tmp/arednsysupgradebackup.tgz -q "$1" 2>&1
 
 rc=$?; if [ $rc != 0 ]; then /sbin/reboot; fi


### PR DESCRIPTION
Tested on UBNT NS M5 XW and CPE210v2.0.