### PR TITLE
Change AREDN site URLs and licensing info

### DIFF
--- a/AREDNLicense.txt
+++ b/AREDNLicense.txt
@@ -8,18 +8,18 @@ Permission is not granted to use the AREDN(TM) marks for any build
 that has been modified from official source channels. 
 
 The AREDN(TM) trademark and AREDN(TM) logo are property of 
-Randolph Smith and are used with Permission. 
+Amateur Radio Emergency Data Network, Inc. and are used with Permission. 
 
 --- End Additional terms --- 
-Permission of Randolph Smith listed below:
+Permission of Amateur Radio Emergency Data Network, Inc. listed below:
 
-I, Randolph Smith, grant a license to use the ARDEN(TM) trademark in
+Amateur Radio Emergency Data Network, Inc. grants a license to use the ARDEN(TM) trademark in
 officially sanctioned AREDN(TM) software releases and promotional material
-including, but not limited to, aredn.com, aredn.net, and aredn.org websites.
+including, but not limited to, arednmesh.org, aredn.com, aredn.net, and aredn.org websites.
 Where questions arise as to the licensed use or the validity of an AREDN(TM)
-software release, the decision of Randolph Smith shall be binding. 
+software release, the decision of Amateur Radio Emergency Data Network, Inc. shall be binding. 
 Upon receipt of a demand all use shall cease within 30 days. This license 
 may be terminated for breach of this condition. This grant is made without
 royalty from the licensee and runs for an indefinite term. 
 
-/s/ Randolph Smith
+/s/ Randolph Smith, President, Amateur Radio Emergency Data Network, Inc.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amateur Radio Emergency Data Network AREDN(tm) Firmware
 
-http://www.aredn.org
+http://www.arednmesh.org
 
 ## Build Information
 

--- a/files/www/about.html
+++ b/files/www/about.html
@@ -60,7 +60,7 @@ The AREDN&trade; trademark and AREDN&trade; logo are property of Randolph Smith 
 --- End Additional terms --- </br>
 Permission of Randolph Smith listed below</br>
 </br>
-I, Randolph Smith, grant a license to use the ARDEN&trade; trademark in officially sanctioned AREDN&trade; software releases and promotional material including, but not limited to, aredn.com, aredn.net, and aredn.org websites. Where questions arise as to the licensed use or the validity of an AREDN&trade; software release, the decision of Randolph Smith shall be binding. Upon receipt of a demand all use shall cease within 30 days. This license may be terminated for breach of this condition. This grant is made without royalty from the licensee and runs for an indefinite term. </br>
+I, Randolph Smith, grant a license to use the ARDEN&trade; trademark in officially sanctioned AREDN&trade; software releases and promotional material including, but not limited to, arednmesh.org, aredn.com, aredn.net, and aredn.org websites. Where questions arise as to the licensed use or the validity of an AREDN&trade; software release, the decision of Randolph Smith shall be binding. Upon receipt of a demand all use shall cease within 30 days. This license may be terminated for breach of this condition. This grant is made without royalty from the licensee and runs for an indefinite term. </br>
 </br>
 /s/ Randolph Smith</br>
 </br>

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -99,7 +99,7 @@ $patch_install = 0;
 %fw_md5 = ();
 
 @serverpaths = (
-    "http://downloads.aredn.org/firmware/ubnt"
+    "http://downloads.arednmesh.org/firmware/ubnt"
 );
 
 # refresh fw

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -71,7 +71,7 @@ if($parms{button_uploaddata})
     my $newsi= sprintf "%s,\"olsr\": %s}",$si, $topo;
 
     # PUT it to the server
-    my $upcurl=`curl -H 'Accept: application/json' -X PUT -d '$newsi' http://data.aredn.org/sysinfo`;
+    my $upcurl=`curl -H 'Accept: application/json' -X PUT -d '$newsi' http://data.arednmesh.org/sysinfo`;
     if($? == 0) {
         push @output, "AREDN online map updated";
     } else {


### PR DESCRIPTION
Change URLS from aredn.org to arednmesh.org
Change license info to Amateur Radio Emergency Data Network, Inc.