### PR TITLE
circleci: debug resolve 'directory not empty error'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,11 @@ jobs:
     docker:
       - image: arednmesh/builder
     steps:
+      - run
+        name: DEBUG
+        command: |
+          pwd
+          ls -la
       - checkout
       - run:
           name: Update Config.mk


### PR DESCRIPTION
trying to resolve a "directory not empty error" upon checkout.  This is not occurring on my repo during testing. 