### PR TITLE
Revert "fix prebuild shellcheck tests to run properly with external s…

### DIFF
--- a/scripts/tests/prebuild/002-usrlocalbin.sh
+++ b/scripts/tests/prebuild/002-usrlocalbin.sh
@@ -71,7 +71,7 @@ do
     if [ "$SHELLCHECKNOTEXISTS" = "1" ]; then
       juLog -name="usrlocalbin_$(basename "$file")" false # Consider test failed if we don't have shellcheck
     else
-      juLog -name="usrlocalbin_$(basename "$file")" shellcheck -x "$file"
+      juLog -name="usrlocalbin_$(basename "$file")" shellcheck "$file"
     fi
   continue # Next file please
   fi


### PR DESCRIPTION
…ources (#5)"

This change brought compatibilty to newer versions of shellcheck.
Unfortanately, current linux OS' do not offer this newer version
and a higher burden to compile and install shellcheck is required.
Consequently, this upgrade will be defered until newer versions
of shellcheck are included by default in linux distribtuions.