### PR TITLE
bugfix: signal charts drop-down list (fixes #48)

### DIFF
--- a/files/usr/lib/lua/aredn/utils.lua
+++ b/files/usr/lib/lua/aredn/utils.lua
@@ -251,3 +251,63 @@ function capture(cmd)
 	handle:close()
 	return(result)
 end
+
+--[[
+LuCI - System library
+
+Description:
+Utilities for interaction with the Linux system
+
+FileId:
+$Id: sys.lua 9662 2013-01-30 13:36:20Z soma $
+
+License:
+Copyright 2008 Steven Barth <steven@midlink.org>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+]]--
+--- Returns the current arp-table entries as two-dimensional table.
+-- @return	Table of table containing the current arp entries.
+--			The following fields are defined for arp entry objects:
+--			{ "IP address", "HW address", "HW type", "Flags", "Mask", "Device" }
+function arptable(callback)
+	local arp, e, r, v
+	if nixio.fs.access("/proc/net/arp") then
+		for e in io.lines("/proc/net/arp") do
+			local r = { }, v
+			for v in e:gmatch("%S+") do
+				r[#r+1] = v
+			end
+
+			if r[1] ~= "IP" then
+				local x = {
+					["IP address"] = r[1],
+					["HW type"]    = r[2],
+					["Flags"]      = r[3],
+					["HW address"] = r[4],
+					["Mask"]       = r[5],
+					["Device"]     = r[6]
+				}
+
+				if callback then
+					callback(x)
+				else
+					arp = arp or { }
+					arp[#arp+1] = x
+				end
+			end
+		end
+	end
+	return arp
+end

--- a/files/usr/local/bin/snrlog
+++ b/files/usr/local/bin/snrlog
@@ -189,7 +189,7 @@ function Neighbor:findNoise()
 end
 
 function Neighbor:findTxMcs()
-	self.tx_mcs=stations[self.mac:upper()].tx_mcs
+	self.tx_mcs=stations[self.mac:upper()].tx_mcs or -1
 	return self.tx_mcs
 end
 
@@ -200,7 +200,7 @@ function Neighbor:findTxRate()
 end
 
 function Neighbor:findRxMcs()
-	self.rx_mcs=stations[self.mac:upper()].rx_mcs
+	self.rx_mcs=stations[self.mac:upper()].rx_mcs or -1
 	return self.rx_mcs
 end
 
@@ -290,7 +290,7 @@ stations=iwinfo["nl80211"].assoclist(wifiiface)
 
 
 -- load up arpcache
-luci.sys.net.arptable(
+arptable(
 	function(a)
 		arpcache[a["HW address"]:lower()]=a
 	end


### PR DESCRIPTION
this is a partial fix.  The drop-down will now populate with IP address.
There remains an issue with name resolution so that the drop-down will contain names (when available).