### PR TITLE
bugfix: Ensure ip2hostname returns shortname

### DIFF
--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -489,7 +489,7 @@ sub ip2hostname
     $reverse_ip=join ".",reverse(split /\./,$ip);
     foreach(`nslookup $ip`)
     {
-	next unless ($host) = /^$reverse_ip\.in-addr\.arpa[ \t]+name[ \t]+=[ \t]+(\S+)/;
+	next unless ($host) = /^$reverse_ip\.in-addr\.arpa[ \t]+name[ \t]+=[ \t]+(\S+)\.local\.mesh/;
 	return $host;
     }
     return "";


### PR DESCRIPTION
Needed to minimize size of OLSR advertisements and
ensure correctness of links in mesh status page

fixes #66