### PR TITLE
ar71xx: Add Support for the TP-LINK CPE210 V3.0 Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Rocket M2 TI | rocket-m-ti? | 64Mb | unknown
 Rocket M5 TI | rocket-m-ti | 64Mb | testing-stable?
 TPLink CPE210 v1.0/v1.1 | cpe210-220-v1 | 64Mb | testing-stable?
 TPLink CPE210 v2.0 | cpe210-v2 | 64Mb | testing-stable?
+TPLink CPE210 v3.0 | cpe210-v2 | 64Mb | testing-stable?
 TPLink CPE510 v1.0/v1.1 | cpe510-220-v1 | 64Mb | testing-stable?
 TPLink CPE510 v2.0 | cpe510-220-v1 | 64Mb | testing-stable?
 Mikrotik BaseBox 2/5 | mikrotik-nand-large | 64Mb | testing-stable?

--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -996,6 +996,16 @@ sub hardware_info
       'rfband'          => '2400',
       'chanpower'       => { 1 => '27', 2 => '28', 9 => '29', 14 => '27' },
     },
+        'TP-Link CPE210 v3.0' => {
+            'name'            => 'TP-Link CPE210 v3.0',
+            'comment'         => 'Testing support for CPE210 v3.0',
+            'supported'       => '-1',
+            'maxpower'        => '25',
+            'pwroffset'       => '0',
+            'usechains'       => 1,
+            'rfband'          => '2400',
+            'chanpower'       => { 1 => '21', 2 => '25', 11 => '18' },
+    },
     'TP-Link CPE510 v1.0' => {
       'name'            => 'TP-Link CPE510 v1.0',
       'comment'         => '',

--- a/patches/001-add_support_for_TP-Link_CPE210_v3.patch
+++ b/patches/001-add_support_for_TP-Link_CPE210_v3.patch
@@ -1,0 +1,21 @@
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -170,7 +170,17 @@ static struct device_info boards[] = {
+ 			"CPE210(TP-LINK|US|N300-2|55530000):2.0\r\n"
+ 			"CPE210(TP-LINK|UN|N300-2):2.0\r\n"
+ 			"CPE210(TP-LINK|EU|N300-2):2.0\r\n"
+-			"CPE210(TP-LINK|US|N300-2):2.0\r\n",
++			"CPE210(TP-LINK|US|N300-2):2.0\r\n"
++                        "CPE210(TP-LINK|EU|N300-2|00000000):3.0\r\n"
++                        "CPE210(TP-LINK|EU|N300-2|45550000):3.0\r\n"
++                        "CPE210(TP-LINK|EU|N300-2|55530000):3.0\r\n"
++                        "CPE210(TP-LINK|UN|N300-2|00000000):3.0\r\n"
++                        "CPE210(TP-LINK|UN|N300-2|45550000):3.0\r\n"
++                        "CPE210(TP-LINK|UN|N300-2|55530000):3.0\r\n"
++                        "CPE210(TP-LINK|US|N300-2|55530000):3.0\r\n"
++                        "CPE210(TP-LINK|UN|N300-2):3.0\r\n"
++                        "CPE210(TP-LINK|EU|N300-2):3.0\r\n"
++                        "CPE210(TP-LINK|US|N300-2):3.0\r\n",
+ 		.support_trail = '\xff',
+ 		.soft_ver = NULL,
+ 

--- a/patches/series
+++ b/patches/series
@@ -1,4 +1,5 @@
 001-add_support_for_TP-Link_CPE510_v2.patch
+001-add_support_for_TP-Link_CPE210_v3.patch
 700-cpe210.patch
 002-firmware-check-fix.patch
 701-extended-spectrum.patch


### PR DESCRIPTION
This Device is almost the same as the CPE210 V2.0
Once Support for the TP-LINK CPE210 V3.0 gets added to the OpenWrt code we
will need to drop the patch 001-add_support_for_TP-Link_CPE210_v3.patch