### PR TITLE
bugfix: allow apostrophes in node description

### DIFF
--- a/files/etc/config.mesh/system
+++ b/files/etc/config.mesh/system
@@ -1,7 +1,7 @@
 config 'system'
 	option 'hostname' '<NODE>'
         option 'timezone' '<time_zone>'
-        option 'description' '<description_node>'
+        option 'description' "<description_node>"
 
 config 'timeserver' 'ntp'
         list 'server'     '<ntp_server>'


### PR DESCRIPTION
node description with apostrophes would not show up on status page.
now it does.
warning message about formatting added to setup page.