### PR TITLE
aredn: Remove square brackets from description on status page

### DIFF
--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -78,7 +78,7 @@ alert_banner();
 print "<h1><big>$node";
 print " / $tactical" if $tactical;
 print "</big></h1>";
-print "[ $node_desc ]" if $node_desc;
+print "$node_desc" if $node_desc;
 print "<hr>\n";
 
 # nav buttons


### PR DESCRIPTION
The square brackets look kind of silly, and if the description goes multi line they will look even worse.