### PR TITLE
build: fix compilation failure for luasrcdiet

### DIFF
--- a/patches/200-luasrcdiet-luci-build.patch
+++ b/patches/200-luasrcdiet-luci-build.patch
@@ -1,0 +1,17 @@
+From bb336671fff613b812b308c7eeeeda38608bda9d Mon Sep 17 00:00:00 2001
+From: Jaymin Patel <Jaymin.Patel@Sophos.com>
+Date: Mon, 30 Jul 2018 15:06:14 +0530
+Subject: [PATCH] fix compilation failure when luasrcdiet is being copied to
+ non existing directory
+
+Signed-off-by: Jaymin Patel <jem.patel@gmail.com>
+--- a/feeds/luci/modules/luci-base/Makefile
++++ b/feeds/luci/modules/luci-base/Makefile
+@@ -41,6 +41,7 @@ endef
+ 
+ define Host/Install
+ 	$(INSTALL_DIR) $(1)/bin
++	$(INSTALL_DIR) $(1)/lib/lua/5.1
+ 	$(INSTALL_BIN) src/po2lmo $(1)/bin/po2lmo
+ 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bin/luasrcdiet $(1)/bin/luasrcdiet
+ 	$(CP) $(HOST_BUILD_DIR)/luasrcdiet $(1)/lib/lua/5.1/

--- a/patches/200-luasrcdiet-luci-build.patch
+++ b/patches/200-luasrcdiet-luci-build.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] fix compilation failure when luasrcdiet is being copied to
  non existing directory
 
 Signed-off-by: Jaymin Patel <jem.patel@gmail.com>
---- a/feeds/luci/modules/luci-base/Makefile
-+++ b/feeds/luci/modules/luci-base/Makefile
+--- openwrt.orig/feeds/luci/modules/luci-base/Makefile
++++ openwrt/feeds/luci/modules/luci-base/Makefile
 @@ -41,6 +41,7 @@ endef
  
  define Host/Install

--- a/patches/series
+++ b/patches/series
@@ -2,6 +2,7 @@
 001-add_support_for_TP-Link_CPE210_v3.patch
 700-cpe210.patch
 002-firmware-check-fix.patch
+200-luasrcdiet-luci-build.patch
 701-extended-spectrum.patch
 702-enable-country-hx.patch
 703-fix-dnsmasq.patch
@@ -12,4 +13,3 @@
 708-define-aredn-vlans.patch
 709-iperf-fw-restart.patch
 710-no-ping6-traceroute6.patch
-200-luasrcdiet-luci-build.patch

--- a/patches/series
+++ b/patches/series
@@ -12,3 +12,4 @@
 708-define-aredn-vlans.patch
 709-iperf-fw-restart.patch
 710-no-ping6-traceroute6.patch
+200-luasrcdiet-luci-build.patch


### PR DESCRIPTION
From bb336671fff613b812b308c7eeeeda38608bda9d Mon Sep 17 00:00:00 2001
From: Jaymin Patel <Jaymin.Patel@Sophos.com>
Date: Mon, 30 Jul 2018 15:06:14 +0530
Subject: [PATCH] fix compilation failure when luasrcdiet is being copied to
 non existing directory

Signed-off-by: Jaymin Patel <jem.patel@gmail.com>