### PR TITLE
bugfix: correct port order on airrouter

### DIFF
--- a/patches/708-define-aredn-vlans.patch
+++ b/patches/708-define-aredn-vlans.patch
@@ -43,7 +43,7 @@
 +		ucidef_set_interface_wan "eth1"
  		ucidef_add_switch "switch0" \
 -			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
-+			"0@eth0" "4:lan:4" "3:lan:3" "2:lan:2" "1t:unused" "1t:dtdlink"
++			"0@eth0" "4:lan:1" "3:lan:2" "2:lan:3" "1t:unused" "1t:dtdlink"
  		;;
  	alfa-ap120c|\
  	all0305|\

--- a/patches/708-define-aredn-vlans.patch
+++ b/patches/708-define-aredn-vlans.patch
@@ -43,7 +43,7 @@
 +		ucidef_set_interface_wan "eth1"
  		ucidef_add_switch "switch0" \
 -			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
-+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4t:unused" "4t:dtdlink"
++			"0@eth0" "4:lan:4" "3:lan:3" "2:lan:2" "1t:unused" "1t:dtdlink"
  		;;
  	alfa-ap120c|\
  	all0305|\


### PR DESCRIPTION
AirRouter should have LAN on ports 1-3 and DTD on port 4.