### PR TITLE
kernel: re-add patch for AT8032 Ethernet PHY

### DIFF
--- a/patches/003-re-add-patch-for-AT8032-Ethernet-PHY.patch
+++ b/patches/003-re-add-patch-for-AT8032-Ethernet-PHY.patch
@@ -1,0 +1,194 @@
+From 20c64dabb67b210c1148820e626fbe0b1dc994f6 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Tue, 31 Jul 2018 04:50:38 +0200
+Subject: [PATCH] kernel: re-add patch for AT8032 Ethernet PHY
+
+The patch was wrongly removed by a kernel version bump to 4.9.106 in
+the believe that it was merged upstream thow it wasn't. This lead to
+unrecoverable link losses on devices which use those PHYs such as
+many ubnt single-port CPEs.
+
+Fixes: 6f8eb1b50f ("kernel: bump 4.9 to 4.9.106 for 18.06")
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+(cherry picked from commit a497e47762)
+---
+ .../902-at803x-add-reset-gpio-pdata.patch     |  8 +--
+ ...et-phy-at803x-add-support-for-AT8032.patch | 70 +++++++++++++++++++
+ ...-at803x-allow-to-configure-via-pdata.patch | 12 ++--
+ ...net-phy-at803x-fix-at8033-sgmii-mode.patch |  2 +-
+ 4 files changed, 81 insertions(+), 11 deletions(-)
+ create mode 100644 target/linux/generic/pending-4.9/180-net-phy-at803x-add-support-for-AT8032.patch
+
+diff --git a/target/linux/ar71xx/patches-4.9/902-at803x-add-reset-gpio-pdata.patch b/target/linux/ar71xx/patches-4.9/902-at803x-add-reset-gpio-pdata.patch
+index fb6f85cdfd1..cb3ed89e985 100644
+--- a/target/linux/ar71xx/patches-4.9/902-at803x-add-reset-gpio-pdata.patch
++++ b/target/linux/ar71xx/patches-4.9/902-at803x-add-reset-gpio-pdata.patch
+@@ -16,7 +16,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
+  #endif /* _PHY_AT803X_PDATA_H */
+ --- a/drivers/net/phy/at803x.c
+ +++ b/drivers/net/phy/at803x.c
+-@@ -263,6 +263,7 @@ static int at803x_resume(struct phy_devi
++@@ -264,6 +264,7 @@ static int at803x_resume(struct phy_devi
+  
+  static int at803x_probe(struct phy_device *phydev)
+  {
+@@ -24,8 +24,8 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
+  	struct device *dev = &phydev->mdio.dev;
+  	struct at803x_priv *priv;
+  	struct gpio_desc *gpiod_reset;
+-@@ -274,6 +275,12 @@ static int at803x_probe(struct phy_devic
+- 	if (phydev->drv->phy_id != ATH8030_PHY_ID)
++@@ -276,6 +277,12 @@ static int at803x_probe(struct phy_devic
++ 	    phydev->drv->phy_id != ATH8032_PHY_ID)
+  		goto does_not_require_reset_workaround;
+  
+ +	pdata = dev_get_platdata(dev);
+@@ -37,7 +37,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
+  	gpiod_reset = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_LOW);
+  	if (IS_ERR(gpiod_reset))
+  		return PTR_ERR(gpiod_reset);
+-@@ -405,15 +412,23 @@ static void at803x_link_change_notify(st
++@@ -407,15 +414,23 @@ static void at803x_link_change_notify(st
+  	 * cannot recover from by software.
+  	 */
+  	if (phydev->state == PHY_NOLINK) {
+diff --git a/target/linux/generic/pending-4.9/180-net-phy-at803x-add-support-for-AT8032.patch b/target/linux/generic/pending-4.9/180-net-phy-at803x-add-support-for-AT8032.patch
+new file mode 100644
+index 00000000000..f2d5df503f8
+--- /dev/null
++++ b/target/linux/generic/pending-4.9/180-net-phy-at803x-add-support-for-AT8032.patch
+@@ -0,0 +1,70 @@
++From: Felix Fietkau <nbd@nbd.name>
++Subject: net: phy: at803x: add support for AT8032
++
++Like AT8030, this PHY needs the GPIO reset workaround
++
++Signed-off-by: Felix Fietkau <nbd@nbd.name>
++---
++
++--- a/drivers/net/phy/at803x.c
+++++ b/drivers/net/phy/at803x.c
++@@ -62,6 +62,7 @@
++ 
++ #define ATH8030_PHY_ID 0x004dd076
++ #define ATH8031_PHY_ID 0x004dd074
+++#define ATH8032_PHY_ID 0x004dd023
++ #define ATH8035_PHY_ID 0x004dd072
++ 
++ MODULE_DESCRIPTION("Atheros 803x PHY driver");
++@@ -259,7 +260,8 @@ static int at803x_probe(struct phy_devic
++ 	if (!priv)
++ 		return -ENOMEM;
++ 
++-	if (phydev->drv->phy_id != ATH8030_PHY_ID)
+++	if (phydev->drv->phy_id != ATH8030_PHY_ID &&
+++	    phydev->drv->phy_id != ATH8032_PHY_ID)
++ 		goto does_not_require_reset_workaround;
++ 
++ 	gpiod_reset = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_LOW);
++@@ -335,7 +337,7 @@ static void at803x_link_change_notify(st
++ 	struct at803x_priv *priv = phydev->priv;
++ 
++ 	/*
++-	 * Conduct a hardware reset for AT8030 every time a link loss is
+++	 * Conduct a hardware reset for AT8030/2 every time a link loss is
++ 	 * signalled. This is necessary to circumvent a hardware bug that
++ 	 * occurs when the cable is unplugged while TX packets are pending
++ 	 * in the FIFO. In such cases, the FIFO enters an error mode it
++@@ -447,6 +449,24 @@ static struct phy_driver at803x_driver[]
++ 	.aneg_done		= at803x_aneg_done,
++ 	.ack_interrupt		= &at803x_ack_interrupt,
++ 	.config_intr		= &at803x_config_intr,
+++}, {
+++	/* ATHEROS 8032 */
+++	.phy_id			= ATH8032_PHY_ID,
+++	.name			= "Atheros 8032 ethernet",
+++	.phy_id_mask		= 0xffffffef,
+++	.probe			= at803x_probe,
+++	.config_init		= at803x_config_init,
+++	.link_change_notify	= at803x_link_change_notify,
+++	.set_wol		= at803x_set_wol,
+++	.get_wol		= at803x_get_wol,
+++	.suspend		= at803x_suspend,
+++	.resume			= at803x_resume,
+++	.features		= PHY_BASIC_FEATURES,
+++	.flags			= PHY_HAS_INTERRUPT,
+++	.config_aneg		= genphy_config_aneg,
+++	.read_status		= genphy_read_status,
+++	.ack_interrupt		= at803x_ack_interrupt,
+++	.config_intr		= at803x_config_intr,
++ } };
++ 
++ module_phy_driver(at803x_driver);
++@@ -454,6 +474,7 @@ module_phy_driver(at803x_driver);
++ static struct mdio_device_id __maybe_unused atheros_tbl[] = {
++ 	{ ATH8030_PHY_ID, 0xffffffef },
++ 	{ ATH8031_PHY_ID, 0xffffffef },
+++	{ ATH8032_PHY_ID, 0xffffffef },
++ 	{ ATH8035_PHY_ID, 0xffffffef },
++ 	{ }
++ };
+diff --git a/target/linux/generic/pending-4.9/734-net-phy-at803x-allow-to-configure-via-pdata.patch b/target/linux/generic/pending-4.9/734-net-phy-at803x-allow-to-configure-via-pdata.patch
+index 8bd9ce3bf77..69b21be9513 100644
+--- a/target/linux/generic/pending-4.9/734-net-phy-at803x-allow-to-configure-via-pdata.patch
++++ b/target/linux/generic/pending-4.9/734-net-phy-at803x-allow-to-configure-via-pdata.patch
+@@ -40,7 +40,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
+  #define AT803X_DEBUG_ADDR			0x1D
+  #define AT803X_DEBUG_DATA			0x1E
+  
+-@@ -71,6 +78,7 @@ MODULE_LICENSE("GPL");
++@@ -72,6 +79,7 @@ MODULE_LICENSE("GPL");
+  struct at803x_priv {
+  	bool phy_reset:1;
+  	struct gpio_desc *gpiod_reset;
+@@ -48,7 +48,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
+  };
+  
+  struct at803x_context {
+-@@ -274,8 +282,16 @@ does_not_require_reset_workaround:
++@@ -276,8 +284,16 @@ does_not_require_reset_workaround:
+  	return 0;
+  }
+  
+@@ -65,7 +65,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
+  	int ret;
+  
+  	ret = genphy_config_init(phydev);
+-@@ -296,6 +312,26 @@ static int at803x_config_init(struct phy
++@@ -298,6 +314,26 @@ static int at803x_config_init(struct phy
+  			return ret;
+  	}
+  
+@@ -92,7 +92,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
+  	return 0;
+  }
+  
+-@@ -333,6 +369,8 @@ static int at803x_config_intr(struct phy
++@@ -335,6 +371,8 @@ static int at803x_config_intr(struct phy
+  static void at803x_link_change_notify(struct phy_device *phydev)
+  {
+  	struct at803x_priv *priv = phydev->priv;
+@@ -100,8 +100,8 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
+ +	pdata = dev_get_platdata(&phydev->mdio.dev);
+  
+  	/*
+- 	 * Conduct a hardware reset for AT8030 every time a link loss is
+-@@ -361,6 +399,24 @@ static void at803x_link_change_notify(st
++ 	 * Conduct a hardware reset for AT8030/2 every time a link loss is
++@@ -363,6 +401,24 @@ static void at803x_link_change_notify(st
+  	} else {
+  		priv->phy_reset = false;
+  	}
+diff --git a/target/linux/generic/pending-4.9/735-net-phy-at803x-fix-at8033-sgmii-mode.patch b/target/linux/generic/pending-4.9/735-net-phy-at803x-fix-at8033-sgmii-mode.patch
+index 1f689850bd7..485567cd768 100644
+--- a/target/linux/generic/pending-4.9/735-net-phy-at803x-fix-at8033-sgmii-mode.patch
++++ b/target/linux/generic/pending-4.9/735-net-phy-at803x-fix-at8033-sgmii-mode.patch
+@@ -24,7 +24,7 @@ Signed-off-by: Roman Yeryomin <roman@advem.lv>
+  #define AT803X_MODE_CFG_MASK			0x0F
+  #define AT803X_MODE_CFG_SGMII			0x01
+  
+-@@ -293,6 +297,27 @@ static int at803x_config_init(struct phy
++@@ -295,6 +299,27 @@ static int at803x_config_init(struct phy
+  {
+  	struct at803x_platform_data *pdata;
+  	int ret;

--- a/patches/series
+++ b/patches/series
@@ -1,8 +1,9 @@
 001-add_support_for_TP-Link_CPE510_v2.patch
 001-add_support_for_TP-Link_CPE210_v3.patch
+002-firmware-check-fix.patch
+003-re-add-patch-for-AT8032-Ethernet-PHY.patch
 200-luasrcdiet-luci-build.patch
 700-cpe210.patch
-002-firmware-check-fix.patch
 701-extended-spectrum.patch
 702-enable-country-hx.patch
 703-fix-dnsmasq.patch


### PR DESCRIPTION
The patch was wrongly removed by a kernel version bump to 4.9.106 in
the believe that it was merged upstream thow it wasn't. This lead to
unrecoverable link losses on devices which use those PHYs such as
many ubnt single-port CPEs.

Fixes: 6f8eb1b50f ("kernel: bump 4.9 to 4.9.106 for 18.06")
Signed-off-by: Daniel Golle <daniel@makrotopia.org>
(cherry picked from commit a497e47762)