### PR TITLE
bugfix: /tmp/hosts dir is missing

### DIFF
--- a/patches/100-dnsmasq-upgrade.patch
+++ b/patches/100-dnsmasq-upgrade.patch
@@ -761,6 +761,7 @@
 +
 +	# before we can call xappend
 +	mkdir -p /var/run/dnsmasq/
++	mkdir -p /tmp/hosts
 +	mkdir -p $(dirname $CONFIGFILE)
 +	mkdir -p /var/lib/misc
 +	touch /tmp/dhcp.leases


### PR DESCRIPTION
names cannot be resolved from node since dnsmasq did not start properly.
errors accessing /tmp/hosts/dhcp since /tmp/hosts does not exist