### PR TITLE
Revert "bugfix: /tmp/hosts dir is missing (#136)"

### DIFF
--- a/patches/100-dnsmasq-upgrade.patch
+++ b/patches/100-dnsmasq-upgrade.patch
@@ -761,7 +761,6 @@
 +
 +	# before we can call xappend
 +	mkdir -p /var/run/dnsmasq/
-+	mkdir -p /tmp/hosts
 +	mkdir -p $(dirname $CONFIGFILE)
 +	mkdir -p /var/lib/misc
 +	touch /tmp/dhcp.leases


### PR DESCRIPTION
Malformed patch.