### PR TITLE
config change to make uhttpd listen on port 80 and 8080

### DIFF
--- a/files/etc/config.ap/firewall
+++ b/files/etc/config.ap/firewall
@@ -64,6 +64,12 @@ config rule
 
 config rule
        option src              wifi
+       option dest_port        80
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
        option dest_port        2222
        option proto    tcp
        option target   ACCEPT

--- a/files/etc/config.ap/firewall
+++ b/files/etc/config.ap/firewall
@@ -63,7 +63,7 @@ config rule
        option target   ACCEPT
 
 config rule
-       option src              wifi
+       option src              wan
        option dest_port        80
        option proto    tcp
        option target   ACCEPT
@@ -77,6 +77,12 @@ config rule
 config rule
        option src              wifi
        option dest_port        8080
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
+       option dest_port        80
        option proto    tcp
        option target   ACCEPT
 

--- a/files/etc/config.ap/uhttpd
+++ b/files/etc/config.ap/uhttpd
@@ -3,6 +3,7 @@ config uhttpd main
 
 	# HTTP listen addresses, multiple allowed
 	list listen_http	0.0.0.0:8080
+	list listen_http	0.0.0.0:80
 	option home		/www
 	option rfc1918_filter 1
 	option cgi_prefix	/cgi-bin

--- a/files/etc/config.client/firewall
+++ b/files/etc/config.client/firewall
@@ -64,6 +64,12 @@ config rule
 
 config rule
        option src              wifi
+       option dest_port        80
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
        option dest_port        2222
        option proto    tcp
        option target   ACCEPT

--- a/files/etc/config.client/firewall
+++ b/files/etc/config.client/firewall
@@ -63,7 +63,7 @@ config rule
        option target   ACCEPT
 
 config rule
-       option src              wifi
+       option src              wan
        option dest_port        80
        option proto    tcp
        option target   ACCEPT
@@ -77,6 +77,12 @@ config rule
 config rule
        option src              wifi
        option dest_port        8080
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
+       option dest_port        80
        option proto    tcp
        option target   ACCEPT
 

--- a/files/etc/config.client/uhttpd
+++ b/files/etc/config.client/uhttpd
@@ -3,6 +3,7 @@ config uhttpd main
 
 	# HTTP listen addresses, multiple allowed
 	list listen_http	0.0.0.0:8080
+	list listen_http	0.0.0.0:80
 	option home		/www
 	option rfc1918_filter 1
 	option cgi_prefix	/cgi-bin

--- a/files/etc/config.mesh/firewall
+++ b/files/etc/config.mesh/firewall
@@ -100,7 +100,7 @@ config rule
        option target   ACCEPT
 
 config rule
-       option src              wifi
+       option src              wan
        option dest_port        80
        option proto    tcp
        option target   ACCEPT
@@ -114,6 +114,12 @@ config rule
 config rule
        option src              wifi
        option dest_port        8080
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
+       option dest_port        80
        option proto    tcp
        option target   ACCEPT
 
@@ -138,6 +144,12 @@ config rule
 config rule
        option src              dtdlink
        option dest_port        8080
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              dtdlink
+       option dest_port        80
        option proto    tcp
        option target   ACCEPT
 

--- a/files/etc/config.mesh/firewall
+++ b/files/etc/config.mesh/firewall
@@ -101,6 +101,12 @@ config rule
 
 config rule
        option src              wifi
+       option dest_port        80
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
        option dest_port        2222
        option proto    tcp
        option target   ACCEPT

--- a/files/etc/config.mesh/uhttpd
+++ b/files/etc/config.mesh/uhttpd
@@ -3,6 +3,7 @@ config uhttpd main
 
 	# HTTP listen addresses, multiple allowed
 	list listen_http	0.0.0.0:8080
+	list listen_http	0.0.0.0:80
 	option home		/www
 	option rfc1918_filter 1
 	option cgi_prefix	/cgi-bin

--- a/files/etc/config.mesh_ap/firewall
+++ b/files/etc/config.mesh_ap/firewall
@@ -62,6 +62,12 @@ config rule
 
 config rule
        option src              wifi
+       option dest_port        80
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
        option dest_port        2222
        option proto    tcp
        option target   ACCEPT

--- a/files/etc/config.mesh_ap/firewall
+++ b/files/etc/config.mesh_ap/firewall
@@ -61,7 +61,7 @@ config rule
        option target   ACCEPT
 
 config rule
-       option src              wifi
+       option src              wan
        option dest_port        80
        option proto    tcp
        option target   ACCEPT
@@ -75,6 +75,12 @@ config rule
 config rule
        option src              wifi
        option dest_port        8080
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
+       option dest_port        80
        option proto    tcp
        option target   ACCEPT
 

--- a/files/etc/config.mesh_ap/uhttpd
+++ b/files/etc/config.mesh_ap/uhttpd
@@ -3,6 +3,7 @@ config uhttpd main
 
 	# HTTP listen addresses, multiple allowed
 	list listen_http	0.0.0.0:8080
+	list listen_http	0.0.0.0:80
 	option home		/www
 	option rfc1918_filter 1
 	option cgi_prefix	/cgi-bin

--- a/files/etc/config.router/firewall
+++ b/files/etc/config.router/firewall
@@ -64,6 +64,12 @@ config rule
 
 config rule
        option src              wifi
+       option dest_port        80
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
        option dest_port        2222
        option proto    tcp
        option target   ACCEPT

--- a/files/etc/config.router/firewall
+++ b/files/etc/config.router/firewall
@@ -63,7 +63,7 @@ config rule
        option target   ACCEPT
 
 config rule
-       option src              wifi
+       option src              wan
        option dest_port        80
        option proto    tcp
        option target   ACCEPT
@@ -77,6 +77,12 @@ config rule
 config rule
        option src              wifi
        option dest_port        8080
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
+       option dest_port        80
        option proto    tcp
        option target   ACCEPT
 

--- a/files/etc/config.router/uhttpd
+++ b/files/etc/config.router/uhttpd
@@ -3,6 +3,7 @@ config uhttpd main
 
 	# HTTP listen addresses, multiple allowed
 	list listen_http	0.0.0.0:8080
+	list listen_http	0.0.0.0:80
 	option home		/www
 	option rfc1918_filter 1
 	option cgi_prefix	/cgi-bin

--- a/files/etc/config/firewall
+++ b/files/etc/config/firewall
@@ -70,6 +70,12 @@ config rule
 
 config rule
        option src              wifi
+       option dest_port        80
+       option proto    tcp
+       option target   ACCEPT
+
+config rule
+       option src              wifi
        option dest_port        698
        option proto    udp
        option target   ACCEPT

--- a/files/etc/config/uhttpd
+++ b/files/etc/config/uhttpd
@@ -3,6 +3,7 @@ config uhttpd main
 
 	# HTTP listen addresses, multiple allowed
 	list listen_http	0.0.0.0:8080
+	list listen_http	0.0.0.0:80
 	option home		/www
 	option rfc1918_filter 1
 	option cgi_prefix	/cgi-bin

--- a/files/etc/local/mesh-firewall/01-tunnels
+++ b/files/etc/local/mesh-firewall/01-tunnels
@@ -59,6 +59,7 @@ if [ $rules_exist -eq 0  ] ; then
         iptables -A zone_vpn_input -p icmp -m icmp --icmp-type 8 -j ACCEPT
         iptables -A zone_vpn_input -p tcp -m tcp --dport 2222 -j ACCEPT
         iptables -A zone_vpn_input -p tcp -m tcp --dport 8080 -j ACCEPT
+        iptables -A zone_vpn_input -p tcp -m tcp --dport 80 -j ACCEPT
         iptables -A zone_vpn_input -p udp -m udp --dport 698 -j ACCEPT
         iptables -A zone_vpn_input -p tcp -m tcp --dport 1978 -j ACCEPT
         iptables -A zone_vpn_input -p tcp -m tcp --dport 23 -j ACCEPT

--- a/files/www/help.html
+++ b/files/www/help.html
@@ -29,7 +29,7 @@ Table of Contents:
 
 Please take note:
 <ul>
-<li>Clicking the AREDN logo will redirect to http://localnode.local.mesh:8080<br><br></li>
+<li>Clicking the AREDN logo will redirect to http://localnode.local.mesh<br><br></li>
 <li>Javascript and page redirection must be enabled in your browser for the
 web interface to work.<br><br></li>
 <li>Some operations can take several seconds, or even longer, to
@@ -52,7 +52,7 @@ web interface to work.<br><br></li>
 <a name=status><h2>Status Page</h2></a>
 <p>
 This is the first page you will see when
-accessing <b>http://localnode:8080/</b> or <b>http://your-node-name:8080/</b>.
+accessing <b>http://localnode/</b> or <b>http://your-node-name/</b>.
 The top bar displays the node name and also a tactical name if one has been
 assigned. For more about tactical names see the <a href='#setup'>Basic Setup</a>
 section.
@@ -147,7 +147,7 @@ temporary files. Memory is the amount of RAM available for running processes.
 	<ul>
 		<li><strong>Archive</strong>: takes you to the charts for any archived signal data on this node.</li>
 		<li><strong>Realtime</strong>: takes you to the charts for realtime (current) signal data as seen from this node.</li>
-	    <li><strong>Quit</strong>: takes you back to the node status page at http://nodename:8080/cgi-bin/status</li>
+	    <li><strong>Quit</strong>: takes you back to the node status page at http://nodename/cgi-bin/status</li>
 	</ul>
 </p>
 <p>Below these control buttons, you will see the <strong>"Selected Device"</strong> drop down control.  This control will display each 'heard' mesh node neighbor.<br>
@@ -459,7 +459,7 @@ If you choose, you can specify your latitude, longitude, and gridsquare for loca
 <li>The <strong>Show Map</strong> button will display a map that allows you to click on the position where your node is located, or, to drag an existing marker to a different location on the map.  Both of these activities will automatically update the lat/lon fields on the page.</li>
 <li>The <strong>Upload Data to AREDN Servers</strong> button will send your node information (no highly sensitive data such as passwords are sent) to an AREDN server on the internet. By submitting this information you hereby allow AREDN to publish your node location on a public mapping service and utilize the information for other such reasons as AREDN determines to be useful, including but not limited to statistical analysis.  If you wish to remove your node location from the public mapping service, simply clear/erase your lat/lon values, "Apply Location Settings", and then "Upload Data to AREDN Servers".</li>
 </ul>
-To see a sample of the information that will be sent to the AREDN server, click <a href='http://localnode.local.mesh:8080/cgi-bin/sysinfo.json?hosts=1'>HERE</a> and <a href='http://localnode.local.mesh:9090/topology'>HERE</a>.  (You can replace "localnode" with your ACTUAL node name to see the data from that node.)<br />
+To see a sample of the information that will be sent to the AREDN server, click <a href='http://localnode.local.mesh/cgi-bin/sysinfo.json?hosts=1'>HERE</a> and <a href='http://localnode.local.mesh:9090/topology'>HERE</a>.  (You can replace "localnode" with your ACTUAL node name to see the data from that node.)<br />
 </p>
 <p>
 You may set the timezone where the node is located as well as setting the NTP server that the node will connect to.  A "Save Changes" button click IS required for timezone and NTS server settings, as well as a subsequent reboot.
@@ -505,7 +505,8 @@ is set up. Here are some common ports:
 <li>698 olsr - optimized link state routing </li>
 <li>1978 olsr http - olsr's web interface </li>
 <li>2222 node ssh server</li>
-<li>8080 node web server</li>
+<li>8080 node web server (old port)</li>
+<li>80 node web server</li>
 </ul>
 <p>
 So then what is port forwarding? Port forwarding is taking an inbound


### PR DESCRIPTION
its time to do this. i'm tired out having to teach new people to mesh how to type in the url and they always forget, especially during our emergency exercises. port 8080 does not make it more secure. it is also very unlikely users have the external interface using a public internet ip address. this change makes it work on both port 8080 for backwards compatibility and port 80 that most users are used to.