### PR TITLE
bugfix:  use bullet-m image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ AirRouter HP | airrouter | 32Mb | stable
 Bullet M2/M2Ti/M5/M5Ti | bullet-m | 32Mb | stable
 Bullet Ti | bullet-m | 32Mb | stable
 NBE-M2-13/16/19 | loco-m-xw | 32Mb | stable
-NanoBridge 2G18 | loco-m | 32Mb | stable
-NanoBridge 5G22/25 | loco-m | 32Mb | stable
-NanoBridge M9 | loco-m | 32Mb | stable
-NanoStation Loco M2/M5/M9 XM | loco-m | 32Mb | stable
+NanoBridge 2G18 | bullet-m | 32Mb | stable
+NanoBridge 5G22/25 | bullet-m | 32Mb | stable
+NanoBridge M9 | bullet-m | 32Mb | stable
+NanoStation Loco M2/M5/M9 XM | bullet-m | 32Mb | stable
 NanoStation Loco M2/M5 XW | loco-m-xw | 64Mb | stable
 NanoStation Loco M5 XW with test date after ~Nov 2017 | rocket-m-xw | 64Mb | stable
 NanoStation  M2/M3/M5 XM | nano-m | 32Mb | stable

--- a/configs/ar71xx-generic.config
+++ b/configs/ar71xx-generic.config
@@ -6,7 +6,6 @@ CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_cpe210-220-v1=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_cpe510-520-v1=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-airrouter=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-bullet-m=y
-CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-loco-m=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-loco-m-xw=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-nano-m-xw=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-nano-m=y


### PR DESCRIPTION
loco-m image correct, did not exist. 