### PR TITLE
aredn: node description, lat/lon display, olsr entries

### DIFF
--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -114,9 +114,9 @@ if(-f "/etc/latlon") {
     close(FILE);
 	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
 }
-($olsrTotal = `ip route list table 30 | wc -l`); #num hosts olsr is keeping track of
-($olsrNodes = `ip route list table 30 | egrep "/" | wc -l`); #num *nodes* on the network (minus other hosts)
-($node_desc = `/sbin/uci get system.\@system[0].description`); #pull the node description from uci
+$olsrTotal = `/sbin/ip route list table 30 | wc -l`; #num hosts olsr is keeping track of
+$olsrNodes = `/sbin/ip route list table 30 | egrep "/" | wc -l`; #num *nodes* on the network (minus other hosts)
+$node_desc = `/sbin/uci get system.\@system[0].description`; #pull the node description from uci
 
 # parse the txtinfo output
 

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -319,7 +319,11 @@ print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>
 
 print "<hr><nobr>";
 
-print "<th align='right'><strong>OLSR Entries</strong> </th><td><nobr>" . `ip route list table 30 | wc -l` . "</td><br><br>";
+print "<table><th align='right'>OLSR Entries</th><td><nobr>Total = " .                                                                                                       
+ `ip route list table 30 | wc -l` .                                                                                          
+ "<nobr><br><nobr>Nodes = " .                                                                                                
+ `ip route list table 30 | egrep "/" | wc -l` .                                                                              
+ "<nobr></td></table>";
 
 # nav buttons
 if(-f "/tmp/web/automesh")

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -106,10 +106,11 @@ system "rm -f /tmp/web/automesh" if $parms{stop};
 $lat_lon = "<strong>Location Not Available</strong>";
 if(-f "/etc/latlon") {
     $rcgood=open(FILE, "/etc/latlon");
-    push @errors, "ERROR: reading lat/lon data\n" unless $rcgood;
-    while(<FILE>){
-        chomp;
-        push @lat_lon,$_;
+    if($rcgood) {
+        while(<FILE>){
+            chomp;
+            push @lat_lon,$_;
+        }
     }
     close(FILE);
 	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -90,7 +90,6 @@ $tactical = nvram_get("tactical");
 $config = nvram_get("config");
 $config = "not set" if $config eq "" or not -d "/etc/config.mesh";
 ($my_ip) = get_ip4_network(get_interface("wifi"));
-$node_desc = `/sbin/uci get system.\@system[0].description`;
 
 chomp ($chanbw = `cat /sys/kernel/debug/ieee80211/phy0/ath9k/chanbw`);
 if    ($chanbw eq "0x00000005") {$chanbw = 4;}
@@ -102,6 +101,21 @@ read_postdata();
 system "mkdir -p /tmp/web";
 system "touch /tmp/web/automesh" if $parms{auto};
 system "rm -f /tmp/web/automesh" if $parms{stop};
+
+$lat_lon = "<strong>Location Not Available</strong>";
+if(-f "/etc/latlon") {
+    $rcgood=open(FILE, "/etc/latlon");
+    push @errors, "ERROR: reading lat/lon data\n" unless $rcgood;
+    while(<FILE>){
+        chomp;
+        push @lat_lon,$_;
+    }
+    close(FILE);
+	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
+}
+($olsrTotal = `ip route list table 30 | wc -l`);
+($olsrNodes = `ip route list table 30 | egrep "/" | wc -l`);
+($node_desc = `/sbin/uci get system.\@system[0].description`);
 
 # parse the txtinfo output
 
@@ -301,29 +315,10 @@ alert_banner();
 # page header
 print "<h1>$node mesh status</h1>";
 
-if(-f "/etc/latlon") {
-    $rcgood=open(FILE, "/etc/latlon");
-    push @errors, "ERROR: reading lat/lon data\n" unless $rcgood;
-    while(<FILE>){
-        chomp;
-        push @lines,$_;
-    }
-    close(FILE);
-    $lat=$lines[0];
-    $lon=$lines[1];
-    print "<center><strong>Location Info</strong> $lat $lon</center>";
-} else {
-    print "<center><strong>Location Info Not Available</strong></center>";
-}
+print "$lat_lon";
 print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>";
-
 print "<hr><nobr>";
-
-print "<table><th align='right'>OLSR Entries</th><td><nobr>Total = " .                                                                                                       
- `ip route list table 30 | wc -l` .                                                                                          
- "<nobr><br><nobr>Nodes = " .                                                                                                
- `ip route list table 30 | egrep "/" | wc -l` .                                                                              
- "<nobr></td></table>";
+print "<table><th align='right'>OLSR Entries</th><td><nobr>Total = $olsrTotal<nobr><br><nobr>Nodes = $olsrNodes<nobr></td></table>";
 
 # nav buttons
 if(-f "/tmp/web/automesh")

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -102,6 +102,7 @@ system "mkdir -p /tmp/web";
 system "touch /tmp/web/automesh" if $parms{auto};
 system "rm -f /tmp/web/automesh" if $parms{stop};
 
+#get location info if available
 $lat_lon = "<strong>Location Not Available</strong>";
 if(-f "/etc/latlon") {
     $rcgood=open(FILE, "/etc/latlon");
@@ -113,9 +114,9 @@ if(-f "/etc/latlon") {
     close(FILE);
 	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
 }
-($olsrTotal = `ip route list table 30 | wc -l`);
-($olsrNodes = `ip route list table 30 | egrep "/" | wc -l`);
-($node_desc = `/sbin/uci get system.\@system[0].description`);
+($olsrTotal = `ip route list table 30 | wc -l`); #num hosts olsr is keeping track of
+($olsrNodes = `ip route list table 30 | egrep "/" | wc -l`); #num *nodes* on the network (minus other hosts)
+($node_desc = `/sbin/uci get system.\@system[0].description`); #pull the node description from uci
 
 # parse the txtinfo output
 
@@ -315,10 +316,10 @@ alert_banner();
 # page header
 print "<h1>$node mesh status</h1>";
 
-print "$lat_lon";
-print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>";
+print "$lat_lon"; #display lat lon info
+print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>"; #display nide description
 print "<hr><nobr>";
-print "<table><th align='right'>OLSR Entries</th><td><nobr>Total = $olsrTotal<nobr><br><nobr>Nodes = $olsrNodes<nobr></td></table>";
+print "<table><th align='right'>OLSR Entries</th><td><nobr>Total = $olsrTotal<nobr><br><nobr>Nodes = $olsrNodes<nobr></td></table>"; #display OLSR numbers
 
 # nav buttons
 if(-f "/tmp/web/automesh")

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -90,6 +90,7 @@ $tactical = nvram_get("tactical");
 $config = nvram_get("config");
 $config = "not set" if $config eq "" or not -d "/etc/config.mesh";
 ($my_ip) = get_ip4_network(get_interface("wifi"));
+$node_desc = `/sbin/uci get system.\@system[0].description`;
 
 chomp ($chanbw = `cat /sys/kernel/debug/ieee80211/phy0/ath9k/chanbw`);
 if    ($chanbw eq "0x00000005") {$chanbw = 4;}
@@ -298,7 +299,27 @@ print "<center>\n";
 alert_banner();
 
 # page header
-print "<h1>$node mesh status</h1><hr><nobr>";
+print "<h1>$node mesh status</h1>";
+
+if(-f "/etc/latlon") {
+    $rcgood=open(FILE, "/etc/latlon");
+    push @errors, "ERROR: reading lat/lon data\n" unless $rcgood;
+    while(<FILE>){
+        chomp;
+        push @lines,$_;
+    }
+    close(FILE);
+    $lat=$lines[0];
+    $lon=$lines[1];
+    print "<center><strong>Location Info</strong> $lat $lon</center>";
+} else {
+    print "<center><strong>Location Info Not Available</strong></center>";
+}
+print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>";
+
+print "<hr><nobr>";
+
+print "<th align='right'><strong>OLSR Entries</strong> </th><td><nobr>" . `ip route list table 30 | wc -l` . "</td><br><br>";
 
 # nav buttons
 if(-f "/tmp/web/automesh")

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -635,7 +635,7 @@ print "
 </tr>
 <tr>
 <td>Node Description (optional)</td>
-<td><textarea rows='2' cols='60' wrap='soft' maxlength='210' id='node_description_entry' name='description_node' tabindex='4'>$description_node</textarea></td>";
+<td><textarea rows='2' cols='60' wrap='soft' maxlength='210' id='node_description_entry' name='description_node' tabindex='4'>$desc</textarea></td>";
 push @hidden, "<input type=hidden name=config value='mesh'>";
 print "
 <td>Verify Password</td>

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -58,6 +58,19 @@ foreach(@wisections) {
     $wifi_ssid = $_->{ssid};
   }
 }
+$lat_lon = "<strong>Location Not Available</strong>";
+if(-f "/etc/latlon") {
+    $rcgood=open(FILE, "/etc/latlon");
+    push @errors, "ERROR: reading lat/lon data\n" unless $rcgood;
+    while(<FILE>){
+        chomp;
+        push @lat_lon,$_;
+    }
+    close(FILE);
+	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
+}
+($olsrTotal = `ip route list table 30 | wc -l`);
+($olsrNodes = `ip route list table 30 | egrep "/" | wc -l`);
 
 read_postdata();
 
@@ -78,20 +91,7 @@ alert_banner();
 print "<h1><big>$node";
 print " / $tactical" if $tactical;
 print "</big></h1>";
-if(-f "/etc/latlon") {
-    $rcgood=open(FILE, "/etc/latlon");
-    push @errors, "ERROR: reading lat/lon data\n" unless $rcgood;
-    while(<FILE>){
-        chomp;
-        push @lines,$_;
-    }
-    close(FILE);
-    $lat=$lines[0];
-    $lon=$lines[1];
-    print "<center><strong>Location Info</strong> $lat $lon</center>";
-} else {
-    print "<center><strong>Location Info Not Available</strong></center>";
-}
+print "<center>$lat_lon</center>";
 print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>" if $node_desc;
 print "<hr>\n";
 
@@ -252,14 +252,7 @@ $str .= $space < 500 ? "<blink><b>$space KB</b></blink>" : "$space KB";
 $str .= "</nobr></td>";
 
 push @col2, $str;
-
-$olsrCount = "<th align='right'>OLSR Entries</th><td><nobr>Total = " .
- `ip route list table 30 | wc -l` .
- "<nobr><br><nobr>Nodes = " .
- `ip route list table 30 | egrep "/" | wc -l` .
- "<nobr></td>";
-
-push @col2, $olsrCount;
+push @col2, "<th align='right'>OLSR Entries</th><td><nobr>Total = $olsrTotal<nobr><br><nobr>Nodes = $olsrNodes<nobr></td>";
 
 # now print the tables
 

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -62,10 +62,11 @@ foreach(@wisections) {
 $lat_lon = "<strong>Location Not Available</strong>";
 if(-f "/etc/latlon") {
     $rcgood=open(FILE, "/etc/latlon");
-    push @errors, "ERROR: reading lat/lon data\n" unless $rcgood;
-    while(<FILE>){
-        chomp;
-        push @lat_lon,$_;
+    if($rcgood) {
+        while(<FILE>){
+            chomp;
+            push @lat_lon,$_;
+        }
     }
     close(FILE);
 	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -58,6 +58,7 @@ foreach(@wisections) {
     $wifi_ssid = $_->{ssid};
   }
 }
+#get location info if available
 $lat_lon = "<strong>Location Not Available</strong>";
 if(-f "/etc/latlon") {
     $rcgood=open(FILE, "/etc/latlon");
@@ -69,8 +70,8 @@ if(-f "/etc/latlon") {
     close(FILE);
 	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
 }
-($olsrTotal = `ip route list table 30 | wc -l`);
-($olsrNodes = `ip route list table 30 | egrep "/" | wc -l`);
+($olsrTotal = `ip route list table 30 | wc -l`); #num hosts olsr is keeping track of
+($olsrNodes = `ip route list table 30 | egrep "/" | wc -l`); #num *nodes* on the network (minus other hosts)
 
 read_postdata();
 
@@ -91,7 +92,7 @@ alert_banner();
 print "<h1><big>$node";
 print " / $tactical" if $tactical;
 print "</big></h1>";
-print "<center>$lat_lon</center>";
+print "<center>$lat_lon</center>"; #display location info
 print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>" if $node_desc;
 print "<hr>\n";
 
@@ -252,7 +253,7 @@ $str .= $space < 500 ? "<blink><b>$space KB</b></blink>" : "$space KB";
 $str .= "</nobr></td>";
 
 push @col2, $str;
-push @col2, "<th align='right'>OLSR Entries</th><td><nobr>Total = $olsrTotal<nobr><br><nobr>Nodes = $olsrNodes<nobr></td>";
+push @col2, "<th align='right'>OLSR Entries</th><td><nobr>Total = $olsrTotal<nobr><br><nobr>Nodes = $olsrNodes<nobr></td>"; #display OLSR numbers
 
 # now print the tables
 

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -78,6 +78,20 @@ alert_banner();
 print "<h1><big>$node";
 print " / $tactical" if $tactical;
 print "</big></h1>";
+if(-f "/etc/latlon") {
+    $rcgood=open(FILE, "/etc/latlon");
+    push @errors, "ERROR: reading lat/lon data\n" unless $rcgood;
+    while(<FILE>){
+        chomp;
+        push @lines,$_;
+    }
+    close(FILE);
+    $lat=$lines[0];
+    $lon=$lines[1];
+    print "<center><strong>Location Info</strong> $lat $lon</center>";
+} else {
+    print "<center><strong>Location Info Not Available</strong></center>";
+}
 print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>" if $node_desc;
 print "<hr>\n";
 
@@ -238,6 +252,9 @@ $str .= $space < 500 ? "<blink><b>$space KB</b></blink>" : "$space KB";
 $str .= "</nobr></td>";
 
 push @col2, $str;
+
+$olsrCount = "<th align='right'>OLSR Entries </th><td><nobr>" . `ip route list table 30 | wc -l` . "</td>";
+push @col2, $olsrCount;
 
 # now print the tables
 

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -70,8 +70,8 @@ if(-f "/etc/latlon") {
     close(FILE);
 	$lat_lon = "<center><strong>Location: </strong> $lat_lon[0] $lat_lon[1]</center>";
 }
-($olsrTotal = `ip route list table 30 | wc -l`); #num hosts olsr is keeping track of
-($olsrNodes = `ip route list table 30 | egrep "/" | wc -l`); #num *nodes* on the network (minus other hosts)
+$olsrTotal = `/sbin/ip route list table 30 | wc -l`; #num hosts olsr is keeping track of
+$olsrNodes = `/sbin/ip route list table 30 | egrep "/" | wc -l`; #num *nodes* on the network (minus other hosts)
 
 read_postdata();
 

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -253,7 +253,12 @@ $str .= "</nobr></td>";
 
 push @col2, $str;
 
-$olsrCount = "<th align='right'>OLSR Entries </th><td><nobr>" . `ip route list table 30 | wc -l` . "</td>";
+$olsrCount = "<th align='right'>OLSR Entries</th><td><nobr>Total = " .
+ `ip route list table 30 | wc -l` .
+ "<nobr><br><nobr>Nodes = " .
+ `ip route list table 30 | egrep "/" | wc -l` .
+ "<nobr></td>";
+
 push @col2, $olsrCount;
 
 # now print the tables


### PR DESCRIPTION

Added node description to mesh status page
Fixes #161

Added Lat/Lon (if available) to status and mesh pages.
It is displayed above the description and under the node name.
Fixes #145

Added OLSR Routing tables entries to status page just under the memory area
Also added this same info just above the buttons on the mesh status page
Fixes #160