### PR TITLE
Fw upload area enhance

### DIFF
--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -88,6 +88,13 @@ $parms{dev} = 1 if -e "/tmp/developer_mode";
 # set the wget command options
 $wget = "wget -U 'node: $node'";
 
+#get device name and firmware type
+$deviceName = `/usr/local/bin/get_model`;
+$fwType = `/usr/local/bin/get_hardwaretype`;
+#strip off "station" from "nanostation"
+#to match the actual name of the fw files
+$fwType =~ s/station//g;
+
 #
 # handle firmware updates
 #
@@ -582,7 +589,7 @@ if(@fw_output)
 }
 
 print "<tr><td align=center colspan=3>current version: $fw_version</td></tr>\n";
-
+print "<tr><td align=center colspan=3>This Device: $deviceName, requires firmware: $fwType</td><tr>";
 print "<tr>\n";
 print "<td>Upload Firmware</td>\n";
 print "<td><input type=file name=firmfile title='choose the firmware file to install from your hard drive'></td>\n";

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -70,9 +70,9 @@ if ( -e "/usr/sbin/vtund" && open(my $tuncfgfd, '/etc/config/vtun')) {
 
 
 if ( $tunnel_active ) {
-    read_postdata({acceptfile => false});
+    read_postdata({acceptfile => 'false'});
 } else {
-    read_postdata({acceptfile => true});
+    read_postdata({acceptfile => 'true'});
 }
 
 reboot_page("/cgi-bin/status") if $parms{button_reboot};


### PR DESCRIPTION
aredn: Info about the device and firmware type needed added above the firmware uploading buttons.
Even I have to double check which firmware is for which device sometimes.
This will hopefully help to alleviate any confusion, and save a few people some sanity. :)

Also got rid of a warning in the syntax checking routines (03-cgibin_admin).