### PR TITLE
aredn: phase 1 support for Mikrotik rb952Ui-5ac2nD

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ TPLink CPE210 v1.0/v1.1 | cpe210-220-v1 | 64Mb | stable
 TPLink CPE210 v2.0/v3.0 | cpe210-v2 | 64Mb | stable
 TPLink CPE510 v1.0/v1.1/v2.0 | cpe510-220-v1 | 64Mb | stable
 Mikrotik BaseBox 2/5 | mikrotik-nand-large | 64Mb | stable
+Mikrotik hAP lite 952Ui-5ac2nD | mikrotik-rb-nor-flash-16M-ac | 64Mb | stable
 
 ### Building with Docker
 Installing the Docker environment on your windows/linux/mac machine is a pre-requisite. A docker 'container' has been pre-configured with an aredn linux build environment. Alternative instructions are below if you wish to setup your linux install with the compiler pre-requisites necessary to do the build.

--- a/configs/ar71xx-mikrotik.config
+++ b/configs/ar71xx-mikrotik.config
@@ -1,5 +1,13 @@
 CONFIG_TARGET_ar71xx=y
 CONFIG_TARGET_ar71xx_mikrotik=y
+CONFIG_TARGET_MULTI_PROFILE=y
 CONFIG_TARGET_SUBTARGET=mikrotik
-CONFIG_TARGET_ar71xx_mikrotik_DEVICE_nand-large=y
+CONFIG_TARGET_DEVICE_ar71xx_mikrotik_DEVICE_nand-large=y
+CONFIG_TARGET_DEVICE_ar71xx_mikrotik_DEVICE_rb-nor-flash-16M-ac=y
+CONFIG_DEFAULT_ath10k-firmware-qca9887=y
+CONFIG_DEFAULT_ath10k-firmware-qca988x=y
+CONFIG_DEFAULT_kmod-ath10k=y
+CONFIG_DEFAULT_kmod-ledtrig-gpio=y
+CONFIG_DEFault_kmod-usb-ehci=y
+CONFIG_DEFAULT_rssileds=y
 CONFIG_PACKAGE_rbcfg=y

--- a/files/etc/config.mesh/wireless
+++ b/files/etc/config.mesh/wireless
@@ -1,4 +1,4 @@
-config wifi-device  radio0
+config wifi-device  <radio>
 	option type     mac80211
 	option channel  <wifi_channel>
         option chanbw   <wifi_chanbw>
@@ -6,16 +6,16 @@ config wifi-device  radio0
         option country <wifi_country>
 	option htmode	HT20
 	option beacon_int 500
-include /etc/aredn_include/radio0path
+include /etc/aredn_include/<radio>path
 
 config wifi-iface
-	option device   radio0
+	option device   <radio>
 	option network	wifi
 	option mode     <wifi_mode>
 	option ssid     "<wifi_ssid>-<wifi_chanbw>-v3"
 	option encryption none
 
 config wifi-iface
-        option device   radio0
+        option device  <radio> 
         option network  wifi_mon
         option mode     monitor

--- a/files/etc/init.d/local
+++ b/files/etc/init.d/local
@@ -9,16 +9,18 @@ boot() {
     mkdir -p /etc/aredn_include
     touch /etc/aredn_include/ethmacfixup
     local lanintf=`uci -q get 'network.lan.ifname'`
-    local wifiintf="wlan0"
+    local wifiintf=`uci -q get 'network.wifi.ifname'`
     local lanmac=`ifconfig $lanintf | grep -o -E '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}'`
     local wifimac=`ifconfig $wifiintf | grep -o -E '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}'`
-    local lanmacdigit=`printf "%X" $(((0x${lanmac:15} + 1) % 256))`
-    local lanmacplusone=${lanmac:0:15}$lanmacdigit
+
+    local intlanmac=${lanmac//:/}
+    local intwanmac=${wifimac//:/}
+    local macdelta=$((0x$intwanmac - 0x$intlanmac))
 
     # Deal with lan and wifi having same mac address (common on TP-Link)
-    # Deal with lan mac + 1 = wifi mac address (common on Microtik and
+    # Deal with lan mac + ~10 = wifi mac address (common on Microtik and
     # breaks OLSR if using derived IP addresses)
-    if [ "$lanmac" = "$wifimac" -o "$lanmacplusone" = "$wifimac" ]
+    if [ $macdelta -le 10 ]
     then
       local wifimacdigit=`printf "%X" $(((0x${wifimac:9:2} + 1) % 256))`
       local newmac=${wifimac:0:9}${wifimacdigit}${wifimac:11}

--- a/files/etc/uci-defaults/99_setup_aredn_include
+++ b/files/etc/uci-defaults/99_setup_aredn_include
@@ -56,16 +56,16 @@ then
 fi
 
 
-# Obtain and store the path to the wireless card so it can be used latter
-if [ -z "$(uci -q get wireless.radio0.path)" ]
-then
-  mkdir -p /etc/aredn_include
-  rm -f /etc/config/wireless
-  wifi detect|grep "option path"|head -n 1 > /etc/aredn_include/radio0path
-  wifi detect > /etc/config/wireless
-else
-  echo "	option path	'$(uci -q get wireless.radio0.path)'" > /etc/aredn_include/radio0path
-fi
+# Obtain and store the path to the wireless cards so it can be used latter
+radiopath=$(uci -q get wireless.radio0.path)
+[ -z "$radiopath" ] && (rm -f /etc/config/wireless;
+                      wifi detect > /etc/config/wireless;
+                      $radiopath=$(uci -q get wireless.radio0.path))
+[ -n "$radiopath" ] && (mkdir -p /etc/aredn_include;
+  echo "	option path	'$radiopath'" > /etc/aredn_include/radio0path)
+
+radiopath=$(uci -q get wireless.radio1.path)
+[ -n "$radiopath" ] && ( echo "	option path	'$radiopath'" > /etc/aredn_include/radio1path)
 
 # Save system NET  LED settings
 if [ ! -f /etc/aredn_include/system_netled ]

--- a/files/usr/local/bin/fccid
+++ b/files/usr/local/bin/fccid
@@ -37,8 +37,11 @@ LICENSE
 
 [ -f /etc/config/run-fccid ] || exit
 
+wifiif=$(uci -q get 'network.wifi.ifname')
+chomp $wifiif;
+
 # stagger the beacons between nodes
-N=$(ifconfig wlan0 | grep "inet addr" | cut -f4 -d. | cut -c1-3)
+N=$(ifconfig $wifiif | grep "inet addr" | cut -f4 -d. | cut -c1-3)
 sleep "$N"
 
-echo "ID: $(uname -n)" | socat - udp4:10.255.255.255:4919,broadcast,so-bindtodevice=wlan0
+echo "ID: $(uname -n)" | socat - udp4:10.255.255.255:4919,broadcast,so-bindtodevice=$wifiif

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -67,10 +67,6 @@ usage() unless defined $config;
 
 die "'$config' is not a valid configuration\n" unless ($config eq "mesh" and -f "/etc/config.mesh/_setup");
 
-#chomp ($node = `nvram get node`);
-#chomp ($mac2 = `nvram get mac2`);
-#chomp ($tactical = `nvram get tactical`);
-
 $node = nvram_get("node");
 $tactical = nvram_get("tactical");
 $mac2 = mac2ip(get_mac(get_interface("wifi")), 0);
@@ -127,12 +123,18 @@ foreach $line (`cat /etc/config.mesh/_setup`)
 }
 
 $cfg{"lan_intf"} = get_interface("lan");
-$cfg{"wifi_intf"} = get_interface("wifi");
+if ( ! $cfg{"wifi_intf"} )
+{
+  $cfg{"wifi_intf"} = get_interface("wifi");
+}
 $cfg{"wan_intf"} = get_interface("wan");
 $cfg{"dtdlink_intf"} = get_interface("dtdlink");
 
-die "configuration load failed\n" unless keys %cfg;
+$cfg{"wifi_intf"} =~ /wlan(\d+)/;
+$radio = ( defined $1 )? "radio$1" : "radio0";
+$cfg{"radio"}=$radio;
 
+die "configuration load failed\n" unless keys %cfg;
 
 # delete some config lines if necessary
 if($cfg{wan_proto} eq "dhcp")
@@ -208,7 +210,10 @@ if($do_basic)
     {
       if($line =~ /^include\s+(\S+)/)
       {
-        foreach $inc (`cat $1`)
+	${incs} = $1;
+        ${incs} =~ s/<radio>/$radio/g;
+	
+        foreach $inc (`cat ${incs}`)
         {
           print OUT $inc;
         }
@@ -219,6 +224,7 @@ if($do_basic)
       $line =~ s/<NODE>/$node/;
       $line =~ s/<MAC2>/$mac2/;
       $line =~ s/<DTDMAC>/$dtdmac/;
+      $line =~ s/<radio>/$radio/;
       $delparm = 0;
 
       while(($parm) = $line =~ /^[^\#].*<(\S+)>/)
@@ -244,11 +250,6 @@ if($do_basic)
   system "mv /tmp/new_config/* /etc/config";
   unlink "/tmp/new_config";
   system "cp -f /etc/config.mesh/firewall.user /etc/";
-
-  #system "nvram set config=mesh";
-  #system "nvram set node=$node";
-  #system "nvram set tactical=$tactical";
-  #system "nvram commit";
 
   nvram_set("config", "mesh");
   nvram_set("node", $node);
@@ -418,7 +419,7 @@ unless($cfg{wifi_proto} eq "disabled")
 {
   $cfg{wifi_txpower} = wifi_maxpower($cfg{wifi_channel}) if not defined $cfg{wifi_txpower} or $cfg{wifi_txpower} > wifi_maxpower($cfg{wifi_channel});
   $cfg{wifi_txpower} = 1  if $cfg{wifi_txpower} < 1;
-  print FILE "/usr/sbin/iw dev wlan0 set txpower fixed $cfg{wifi_txpower}00\n";
+  print FILE "/usr/sbin/iw dev $cfg{wifi_intf} set txpower fixed $cfg{wifi_txpower}00\n";
   if(defined $cfg{aprs_lat} and defined $cfg{aprs_lon})
   {
     printf FILE "echo %s,%s > /tmp/latlon.txt\n", $cfg{aprs_lat}, $cfg{aprs_lon};

--- a/files/usr/local/bin/nvram-setup
+++ b/files/usr/local/bin/nvram-setup
@@ -52,19 +52,31 @@ sub fail
   die "@_\n";
 }
 
+sub get_wlan2phy
+{
+  my ($wlan) = $1;
+  my ($phy) = "";
+  return "phy0" unless $wlan;
+  foreach(`iwinfo  $wlan info`)
+  {
+    next unless /^.*PHY name:\s*([a-z0-4]+)/;
+    $phy = $1;
+  }
+  return $phy;
+}
+
 $commit = 0;
+$wifiif = `uci -q get network.wifi.ifname`;
+$phy = get_wlan2phy("$wifiif");
 
-# Added new wifimac parm, the radio0 wont startup without it, use the path location in wifi config
+# Added new wifimac parm, the radio* wont startup without it, use the path location in wifi config
 # Actually it just needs some path to get to the radio.
-
-# Using radio0.path as it seems to always be set as method to get to the card.
-chomp ($wifi_path = `uci -q get wireless.radio0.path`);
 
 chomp ($wifi_mac = `uci -c /etc/local/uci/ -q get hsmmmesh.settings.wifimac`);
 
 if($wifi_mac eq "")
 {
-  open(FILE, "/sys/devices/$wifi_path/ieee80211/phy0/macaddress") or fail("ERROR: wireless mac not available");
+  open(FILE, "/sys/class/ieee80211/${phy}/macaddress") or fail("ERROR: wireless mac not available");
   while(<FILE>)
   {
     next unless /(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/;
@@ -82,7 +94,7 @@ chomp ($mac2 = `uci -c /etc/local/uci/ -q get hsmmmesh.settings.mac2`);
 
 if($mac2 eq "")
 {
-  open(FILE, "/sys/devices/$wifi_path/ieee80211/phy0/macaddress") or fail("ERROR: wireless mac not available");
+  open(FILE, "/sys/class/ieee80211/${phy}/macaddress") or fail("ERROR: wireless mac not available");
   while(<FILE>)
   {
     next unless /\w\w:\w\w:\w\w:(\w\w):(\w\w):(\w\w)/;

--- a/files/usr/local/bin/rssi_monitor
+++ b/files/usr/local/bin/rssi_monitor
@@ -44,7 +44,14 @@ chomp $now;
 
 exit 0 unless $now > 119;
 
-$iface = "wlan0" ; # wireless interface
+chomp ($iface=`uci -q get 'network.wifi.ifname'`); # wireless interface
+foreach(`iwinfo $iface info`)
+{ 
+  next unless /^.*PHY name:\s*([a-z0-4]+)/;
+  $phy = $1;
+}
+$phy = "phy0" unless $phy;
+
 $datfile = "/tmp/rssi.dat";
 $logfile = "/tmp/rssi.log";
 
@@ -57,7 +64,7 @@ sub getRSSI
     delete $rssi{$_};
   }
 
-  chomp ($stationCount = `ls -1 /sys/kernel/debug/ieee80211/phy0/netdev:${iface}/stations | wc -l`); 
+  chomp ($stationCount = `ls -1 /sys/kernel/debug/ieee80211/${phy}/netdev:${iface}/stations | wc -l`); 
 
   if ($stationCount >= 1) 
   {
@@ -96,7 +103,9 @@ sub getRSSI
 
 sub getChannelScan
 {
-  $chnum = `uci get wireless.radio0.channel`;
+  $iface =~ /wlan(\d+)/;
+  $radio = "radio$1";
+  $chnum = `uci get wireless.$radio.channel`;
   $chnum += 1;
   if ($chnum == 8 or $chnum == 12 or $chnum == 100 or $chnum == 185) { $chnum -= 2; }
   if ($chnum == 0) { $chnum = 1; }
@@ -105,7 +114,7 @@ sub getChannelScan
   $freq = $1;
 }
 
-$antnum=`cat /sys/kernel/debug/ieee80211/phy0/ath9k/tx_chainmask`;
+$antnum=`cat /sys/kernel/debug/ieee80211/${phy}/ath9k/tx_chainmask`;
 if ($antnum == "1")
 {
   $antnum=0;
@@ -140,7 +149,7 @@ if ( -e $datfile )
   close FILE ;
 }
 
-$ofdm_level = `cat /sys/kernel/debug/ieee80211/phy0/ath9k/ani | grep "OFDM LEVEL" | cut -f2 -d: `;
+$ofdm_level = `cat /sys/kernel/debug/ieee80211/${phy}/ath9k/ani | grep "OFDM LEVEL" | cut -f2 -d: `;
 $now=`cat /proc/uptime | cut -f1 -d" "`;
 chomp $now;
 

--- a/files/usr/local/bin/wscan
+++ b/files/usr/local/bin/wscan
@@ -133,11 +133,22 @@ $batch = 0;     # batch mode
 $loops = 0;     # number of times to run 0=inf
 $raw = 0;       # raw mode
 $openap = 0;    # show open ap's
-$iface = "wlan0"; # wireless interface
+$iface = `uci -q get 'network.wifi.ifname'`; # wireless interface
+chomp $iface;
 
 $iters = 0;     # number of iterations
 %avgs = ();     # average statistics
 %aphash = ();   # list of ap's for avg mode
+
+$mychan = `iwinfo $iface info | grep -i channel`;
+$mychan =~ /Channel:\s+(-*\d+)/;
+$mychan = ( ! defined $1 || ! int($1) || ! ($1 >= -2 && $1 <= 185) ) ? 0 : $1;
+
+# ch 76 - 99 are 3ghz since no part 15 usage (5ghz board with -2ghz transverter)
+if ($mychan >= 76 and $mychan <= 99)
+{
+  $mychan = ($mychan*5+3000);
+}
 
 while(defined ($arg = shift))
 {
@@ -157,23 +168,18 @@ die "bad interface" if not defined $iface;
 
 if($raw)
 {
-  system("/usr/bin/iw dev $iface scan");
-  system("/usr/sbin/iw dev $iface station dump");
+  system("iw dev $iface scan");
+  system("iw dev $iface station dump");
   exit;
 }
 
 while(1)
 {
-  $line = `grep ssid /etc/config/wireless | tail -1`;
+  $line = `egrep "['\\"].*-(5|10|20)-v[3456]" /etc/config/wireless | head -1`;
   $line   =~ /['"](.*-(5|10|20)-v[3456])/;
   $myssid = $1;
-  $mychan = `iw dev $iface info | grep channel | cut -d\\  -f2`;
-  if ($mychan >= 76 and $mychan <= 99)
-  {
-    $mychan = ($mychan*5+3000); # ch 76 - 99 are 3ghz since no part 15 usage (5ghz board with -2ghz transverter)
-  }
 
-  open(FILE, "/usr/sbin/iw dev $iface scan 2>&1 |") or die "iw scan failed";
+  open(FILE, "iw dev $iface scan 2>&1 |") or die "iw scan failed";
   $mac = "";
   $host = "N/A";
   $lastseen = 0;
@@ -222,7 +228,7 @@ while(1)
   $lastseen = 0;
   ++$iters;
 
-  open(FILE, "/usr/sbin/iw $iface station dump 2>&1 |") or die "/usr/sbin/iw failed";
+  open(FILE, "iw dev $iface station dump 2>&1 |") or die "iw failed";
 
   while($line = <FILE>)
   {

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -90,8 +90,11 @@ $tactical = nvram_get("tactical");
 $config = nvram_get("config");
 $config = "not set" if $config eq "" or not -d "/etc/config.mesh";
 ($my_ip) = get_ip4_network(get_interface("wifi"));
+${wifiif} = `uci -q get 'network.wifi.ifname'`;
+chomp ${wifiif};
+$phy = get_wlan2phy("${wifiif}");
 
-chomp ($chanbw = `cat /sys/kernel/debug/ieee80211/phy0/ath9k/chanbw`);
+chomp ($chanbw = `cat /sys/kernel/debug/ieee80211/${phy}/ath9k/chanbw`);
 if    ($chanbw eq "0x00000005") {$chanbw = 4;}
 elsif ($chanbw eq "0x0000000a") {$chanbw = 2;}
   else   			{$chanbw = 1;}
@@ -140,18 +143,18 @@ foreach(`echo /all | nc 127.0.0.1 2006 2>$tmperr`)
 	$links{$ip}{lq} = $lq;
 	$links{$ip}{nlq} = $nlq;
 
-	$mac = `grep $ip /proc/net/arp | grep wlan0 | grep -v "00:00:00:00:00:00" | head -1`;
+	$mac = `grep $ip /proc/net/arp | grep ${wifiif} | grep -v "00:00:00:00:00:00" | head -1`;
 	$mac =~ s/^.*(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w).*$/$1/;
 	chomp $mac;
 
-        if (! $mac or ! -e "/sys/kernel/debug/ieee80211/phy0/netdev:wlan0/stations/$mac" )
+        if (! $mac or ! -e "/sys/kernel/debug/ieee80211/${phy}/netdev:${wifiif}/stations/$mac" )
 	{
 		$mbps = "";
 	}
         else
         {
 		#802.11b/n
-		$mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/phy0/netdev\:wlan0/stations/$mac/rc_stats_csv`;
+		$mbps = `egrep '^([^,]*,){3}A' /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
 		if ($mbps)
 		{
 			($gi, $dummy, $rate, $dummy, $ewma) = $mbps =~ /^[^,]*,([^,]*),([^,]*,){2}([^,]*),([^,]*,){4}([^,]*).*$/ ;
@@ -161,7 +164,7 @@ foreach(`echo /all | nc 127.0.0.1 2006 2>$tmperr`)
 		else
 		{
 			#802.11a/b/g
-			$mbps = `egrep \"^A" /sys/kernel/debug/ieee80211/phy0/netdev\:wlan0/stations/$mac/rc_stats_csv`;
+			$mbps = `egrep \"^A" /sys/kernel/debug/ieee80211/${phy}/netdev\:${wifiif}/stations/$mac/rc_stats_csv`;
 			if ($mbps)
 			{
 				$mbps =~ /^[^,]*,([^,]*),([^,]*,){4}([^,]*).*$/;

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -56,6 +56,8 @@ read_postdata();
 
 my $tz_db_strings = tz_names_hash();
 my $tz_db_names = tz_names_array();
+$wifiintf = get_interface("wifi");
+$phy = get_wlan2phy("$wifiintf");
 
 if($parms{button_uploaddata})
 {
@@ -157,7 +159,6 @@ $parms{dmz_dhcp_limit} = $dmz_dhcp_limit = $dmz_dhcp_end - $dmz_dhcp_start + 1;
 
 unless($parms{reload})
 {
-    my $wifiintf = get_interface("wifi");
     ($wifi_txpower) = `iwinfo $wifiintf info 2>/dev/null` =~ /Tx-Power: (\d+)/;
     (my $doesiwoffset) = `iwinfo $wifiintf info 2>/dev/null` =~ /TX power offset: (\d+)/;
     if ( $doesiwoffset ) {
@@ -186,9 +187,8 @@ if($parms{button_apply} or $parms{button_save})
     {
         push (@errors, "invalid distance value");
     } else {
-        my $wifiintf = get_interface("wifi");
         $cmd = "";
-        $cmd .= "iw phy phy0 set distance $wifi_distance >/dev/null 2>&1;";
+        $cmd .= "iw phy ${phy} set distance $wifi_distance >/dev/null 2>&1;";
         $cmd .= "iw dev $wifiintf set txpower fixed ${wifi_txpower}00 >/dev/null 2>&1;";
         system $cmd;
     }

--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -47,9 +47,12 @@ $node = "NOCALL" if $node eq "";
 $tactical = nvram_get("tactical");
 $config = nvram_get("config");
 $config = "not set" if $config eq "" or not -d "/etc/config.mesh";
+$wifi_iface = get_interface("wifi");
+$wifi_iface =~ /wlan(\d+)/;
+$radio = ( defined $1 )? "radio$1" : "radio0";
 
-($junk, $wifi_channel) = &uci_get_named_option("wireless", "radio0", "channel");
-($junk, $wifi_chanbw) = &uci_get_named_option("wireless", "radio0", "chanbw");
+($junk, $wifi_channel) = &uci_get_named_option("wireless", "$radio", "channel");
+($junk, $wifi_chanbw) = &uci_get_named_option("wireless", "$radio", "chanbw");
 ($junk, $node_desc) = &uci_get_indexed_option("system", "system", "0", "description");
 $wifi_ssid = "N/A";
 @wisections = &uci_get_all_indexed_by_sectiontype("wireless", "wifi-iface");
@@ -158,10 +161,10 @@ $browser_ip = "";
 # left column - network interface info
 
 # show the wifi address
-($ip, $mask, $bcast, $net, $cidr) = get_ip4_network(get_interface("wifi"));
+($ip, $mask, $bcast, $net, $cidr) = get_ip4_network($wifi_iface);
 $cidr = "/ $cidr" if $cidr;
 $str  = "<th align=right><nobr>WiFi address</nobr></th><td>$ip <small>$cidr</small><br>";
-$str .= "<small><nobr>" . get_ip6_addr(get_interface("wifi")) . "</nobr></small></td>";
+$str .= "<small><nobr>" . get_ip6_addr($wifi_iface) . "</nobr></small></td>";
 push @col1, $str;
 
 # find out if the browser is on this node's lan
@@ -225,7 +228,7 @@ push @col1, $str . "</td>";
 if($config eq "mesh")
 {
     $str = "<th align=right valign=middle><nobr>Signal/Noise/Ratio</nobr></th><td valign=middle><nobr>";
-    ($s, $n) = get_wifi_signal(get_interface("wifi"));
+    ($s, $n) = get_wifi_signal($wifi_iface);
     if($s eq "N/A") { $str .= "N/A" }
     else            { $str .= sprintf "<big><b>%d / %d / %d dB</b></big>", $s, $n, $s - $n }
     $str .= "&nbsp;&nbsp;&nbsp;";

--- a/files/www/cgi-bin/supporttool
+++ b/files/www/cgi-bin/supporttool
@@ -36,6 +36,8 @@
 
 BEGIN {push @INC, '/www/cgi-bin'};
 use perlfunc;
+chomp (${wifiif}=`uci -q get 'network.wifi.ifname'`);
+$phy=get_wlan2phy("${wifiif");
 
 
 @files = ( "/etc/config/",
@@ -75,11 +77,11 @@ use perlfunc;
           "ip route list table default",
           "ip rule list",
           "iwinfo",
-          "iwinfo wlan0 assoclist",
-          "iw phy phy0 info",
-          "iw dev wlan0 info",
-          "iw dev wlan0 scan",
-          "iw dev wlan0 station dump",
+          "iwinfo ${wifiif} assoclist",
+          "iw phy ${phy} info",
+          "iw dev ${wifiif} info",
+          "iw dev ${wifiif} scan",
+          "iw dev ${wifiif} station dump",
           "logread",
           "md5sum /www/cgi-bin/*",
           "echo /all | nc 127.0.0.1 2006",

--- a/files/www/cgi-bin/sysinfo.json
+++ b/files/www/cgi-bin/sysinfo.json
@@ -168,7 +168,7 @@ local ift=get_interfaces()
 for pos, i in pairs(ift) do
 	local nim={}
 	local ipv4=""
-	if (i.name ~= "lo" and i.name ~= "wlan0-1") then
+	if (i.name ~= "lo" and i.name ~= "wlan0-1" and i.name ~= "wlan1-1") then
 		--table.print(i)
 		nim['name']=i.name
 		ipv4=tostring(i.ipaddrs[1])

--- a/patches/708-define-aredn-networks.patch
+++ b/patches/708-define-aredn-networks.patch
@@ -32,43 +32,56 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
 ===================================================================
 --- openwrt.orig/target/linux/ar71xx/base-files/etc/board.d/02_network
 +++ openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
-@@ -13,7 +13,7 @@ ar71xx_setup_interfaces()
+@@ -12,8 +12,9 @@ ar71xx_setup_interfaces()
+ 
  	case "$board" in
  	airgatewaypro)
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
  		ucidef_add_switch "switch0" \
 -			"0@eth0" "4:lan" "5:wan"
 +			"0@eth0" "4:lan" "5t:wan" "5t:dtdlink"
  		;;
  	airrouter|\
  	ap121|\
-@@ -57,9 +57,9 @@ ar71xx_setup_interfaces()
+@@ -57,9 +58,10 @@ ar71xx_setup_interfaces()
  	whr-hp-gn|\
  	wzr-hp-ag300h|\
  	zbt-we1526)
 -		ucidef_set_interfaces_lan_wan "eth0.1" "eth1"
 +		ucidef_set_interface_wan "eth1"
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
  		ucidef_add_switch "switch0" \
 -			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 +			"0@eth0" "4:lan:1" "3:lan:2" "2:lan:3" "1t:unused" "1t:dtdlink"
  		;;
  	alfa-ap120c|\
  	all0305|\
-@@ -150,7 +150,8 @@ ar71xx_setup_interfaces()
+@@ -150,7 +152,9 @@ ar71xx_setup_interfaces()
  	wifi-pineapple-nano|\
  	wndap360|\
  	wp543)
 -		ucidef_set_interface_lan "eth0"
-+		ucidef_set_interfaces_lan_wan "eth0" "eth0.1" 
++		ucidef_set_interfaces_lan_wan "eth0" "eth0.1"
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
 +		ucidef_set_interface_raw "dtdlink" "eth0.2" "static"
  		;;
  	a40|\
  	a60|\
-@@ -177,15 +178,16 @@ ar71xx_setup_interfaces()
+@@ -169,7 +173,6 @@ ar71xx_setup_interfaces()
+ 	pb42|\
+ 	pb44|\
+ 	rb-951ui-2hnd|\
+-	rb-952ui-5ac2nd|\
+ 	routerstation|\
+ 	tl-wr710n|\
+ 	tl-wr720n-v3|\
+@@ -177,15 +180,25 @@ ar71xx_setup_interfaces()
  	tl-wr810n-v2|\
  	wpe72|\
  	wrtnode2q)
 -		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 +		ucidef_set_interfaces_lan_wan "eth0" "eth0.1"
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
 +		ucidef_set_interface_raw "dtdlink" "eth0.2" "static"
  		;;
  	rb-750-r2|\
@@ -77,66 +90,87 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  	rb-951ui-2nd)
 -		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
 +		ucidef_set_interface_wan "eth0"
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
  		ucidef_add_switch "switch0" \
 -			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 +			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4t:unused" "4t:dtdlink"
++		;;
++	rb-952ui-5ac2nd)
++		ucidef_set_interface_wan "eth0"
++		ucidef_set_interface_raw "wifi" "wlan1" "static"
++		ucidef_set_interface_raw "wifiap" "wlan0" "dhcp"
++		ucidef_add_switch "switch0" \
++		"0@eth1" "4:lan:1" "3:lan:2" "2:lan:3" "1t:unused" "1t:dtdlink"
  		;;
  	all0258n|\
  	all0315n|\
-@@ -195,7 +197,8 @@ ar71xx_setup_interfaces()
+@@ -195,7 +208,9 @@ ar71xx_setup_interfaces()
  	ja76pf2|\
  	rocket-m-ti|\
  	ubnt-unifi-outdoor)
 -		ucidef_set_interface_lan "eth0 eth1"
 +		ucidef_set_interfaces_lan_wan "eth0" "eth0.1"
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
 +		ucidef_set_interface_raw "dtdlink" "eth0.2" "static"
  		;;
  	wzr-hp-g300nh2)
  		ucidef_add_switch "switch0" \
-@@ -211,7 +214,7 @@ ar71xx_setup_interfaces()
+@@ -210,8 +225,9 @@ ar71xx_setup_interfaces()
+ 	rb-962uigs-5hact2hnt|\
  	wlr8100|\
  	wzr-hp-g450h)
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
  		ucidef_add_switch "switch0" \
 -			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"
 +			"0@eth0" "2:lan" "3:lan" "4:lan" "1:wan" "5t:dtdlink"
  		;;
  	ap135-020|\
  	ap136-020|\
-@@ -292,7 +295,7 @@ ar71xx_setup_interfaces()
+@@ -291,11 +307,13 @@ ar71xx_setup_interfaces()
+ 	cpe510|\
  	wbs210|\
  	wbs510)
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
  		ucidef_add_switch "switch0" \
 -			"0@eth0" "5:lan" "4:wan"
 +			"0@eth0" "5:lan" "4t:wan" "4t:dtdlink"
  		;;
  	cr3000)
  		ucidef_set_interfaces_lan_wan "eth0.1" "eth1"
-@@ -449,7 +452,7 @@ ar71xx_setup_interfaces()
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+ 		;;
+@@ -448,8 +466,9 @@ ar71xx_setup_interfaces()
+ 			"0@eth0" "1:lan" "5:wan" "6@eth1"
  		;;
  	nanostation-m-xw)
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
  		ucidef_add_switch "switch0" \
 -			"0@eth0" "5:lan" "1:wan"
 +			"0@eth0" "5:lan" "1t:wan" "1t:dtdlink"
  		;;
  	onion-omega)
  		ucidef_set_interface_lan "wlan0"
-@@ -460,9 +463,9 @@ ar71xx_setup_interfaces()
+@@ -460,9 +479,10 @@ ar71xx_setup_interfaces()
  			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5@eth1"
  		;;
  	routerstation-pro)
 -		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
 +		ucidef_set_interface_wan "eth0"
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
  		ucidef_add_switch "switch0" \
 -			"0@eth1" "2:lan:3" "3:lan:2" "4:lan:1"
 +			"0@eth1" "2:lan:3" "3:lan:2" "4t:unused" "4t:dtdlink"
  		;;
  	rb-493g)
  		ucidef_set_interfaces_lan_wan "eth0.1 eth1.1" "eth1.2"
-@@ -564,7 +567,8 @@ ar71xx_setup_interfaces()
+@@ -564,7 +584,9 @@ ar71xx_setup_interfaces()
  			"0@eth0" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4" "5:wan"
  		;;
  	*)
 -		ucidef_set_interfaces_lan_wan "eth0" "eth1"
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
 +		ucidef_set_interfaces_lan_wan "eth0" "eth0.1"
 +		ucidef_set_interface_raw "dtdlink" "eth0.2" "static"
  		;;

--- a/patches/series
+++ b/patches/series
@@ -9,6 +9,6 @@
 705-aredn-banner.patch
 706-MeshNode-SSID.patch
 707-enable-board-name.patch
-708-define-aredn-vlans.patch
+708-define-aredn-networks.patch
 709-iperf-fw-restart.patch
 710-no-ping6-traceroute6.patch


### PR DESCRIPTION
Add support for the hAP lite model rb952UI-5ac2nD equivilent to
the UBNT AirRouter.  The 5Ghz interface will be configured in a
2nd phase.  This hAP lite model has double the RAM and Flash
of the AR.  the 2Ghz is MIMO (5Ghz is single antenna).