### PR TITLE
aredn: Changed placement of OLSR info on the mesh status page.

### DIFF
--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -321,9 +321,8 @@ alert_banner();
 print "<h1>$node mesh status</h1>";
 
 print "$lat_lon"; #display lat lon info
-print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>"; #display nide description
+print "<table id='node_description_display'><tr><td>$node_desc</td></tr></table>"; #display node description
 print "<hr><nobr>";
-print "<table><th align='right'>OLSR Entries</th><td><nobr>Total = $olsrTotal<nobr><br><nobr>Nodes = $olsrNodes<nobr></td></table>"; #display OLSR numbers
 
 # nav buttons
 if(-f "/tmp/web/automesh")
@@ -582,7 +581,7 @@ else
     print "<tr><td>none</td></tr>\n";
 }
 
-
+print "<td colspan=5></td><th align='right'>OLSR Entries</th><td><nobr>Total = $olsrTotal<nobr><br><nobr>Nodes = $olsrNodes<nobr></td>"; #display OLSR numbers
 print "</table></td></tr></table>\n";
 
 


### PR DESCRIPTION
Moved to be under the Previous Neighbors area.
It's actually under the previous neighbors listing
Fixes #171 

It's ugly where it is now, this is better, and eventually we'll find a good home for this info. :smile: