### PR TITLE
aredn: preserve custom firewall rules across sysupgrade

### DIFF
--- a/files/etc/arednsysupgrade.conf
+++ b/files/etc/arednsysupgrade.conf
@@ -23,6 +23,7 @@
 /etc/dropbear/dropbear_dss_host_key
 /etc/dropbear/dropbear_rsa_host_key
 /etc/dropbear/authorized_keys
+/etc/local/mesh-firewall/59-custom-rules
 /etc/firewall.user
 /etc/group
 /etc/hosts

--- a/files/etc/local/mesh-firewall/59-custom-rules
+++ b/files/etc/local/mesh-firewall/59-custom-rules
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# add custom firewall rules into this file to preserve across
+# sysupgrades
+
+# example rules to forward from home network
+# to access an ipCam somewhere on the mesh
+# on home network use the IP address of the WAN assigned to the mesh node
+# to access the ipcam, e.g.  http://192.168.1.59:8082
+
+#iptables -t nat -A zone_wan_prerouting       -p tcp -m tcp --dport 8082 		-j DNAT		    --to <IP address of ipcam>            -m comment --comment "my mesh ipCam"
+#iptables -t nat -A zone_wifi_postrouting     -p tcp -m tcp -d <IP address of ipcam>	-j SNAT --dport 80  --to-source <IP wifi on this node>    -m comment --comment "my mesh ipCam"
+#iptables -t nat -A zone_dtdlink_postrouting  -p tcp -m tcp -d <IP address of ipcam>	-j SNAT --dport 80  --to-source <IP dtdlink on this node> -m comment --comment "my mesh ipCam"
+


### PR DESCRIPTION
groups with custom rules created in /etc/local/mesh-firewall
for echolink, ampr.net, and other integrations with internet
based appications can preserve rules across a firmware
upgrade by locating the custom rules in this directory
using a file named 59-custom-rules