### PR TITLE
bugfix: show freq on status page instead of channel number for 3GHz

### DIFF
--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -52,6 +52,10 @@ $wifi_iface =~ /wlan(\d+)/;
 $radio = ( defined $1 )? "radio$1" : "radio0";
 
 ($junk, $wifi_channel) = &uci_get_named_option("wireless", "$radio", "channel");
+if ($wifi_channel >= 76 and $wifi_channel <= 99)
+{
+  $wifi_channel = ($wifi_channel*5+3000);
+}
 ($junk, $wifi_chanbw) = &uci_get_named_option("wireless", "$radio", "chanbw");
 ($junk, $node_desc) = &uci_get_indexed_option("system", "system", "0", "description");
 $wifi_ssid = "N/A";


### PR DESCRIPTION
3GHz has no common assignment of channel numbers, given no part 15
coverage in the US.  AREDN devices show freq in place of a channel
number for 3GHz.