### PR TITLE
bugfix: Check for existing hostnames on the network in DHCP reservations

### DIFF
--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -309,6 +309,22 @@ foreach $val (@list)
                 last;
             }
         }
+        my $olsrFile = 0;
+        $olsrFile = 1 if -f "/var/run/hosts_olsr";
+        my $foundHost = 0;
+        if($olsrFile) {
+          open(my $hostFile, "<", "/var/run/hosts_olsr");
+          while(<$hostFile>) {
+            if($_ =~ /\t$host\t/) {
+              $foundHost = 1;
+              last;
+            }
+          }
+          close($hostFile);
+          push(@dhcp_err, "$val <font color='red'>Warning!</font> '$host' is already in use!<br>" .
+            "Please choose another hostname.<br>" .
+            "Prefixing the hostname with your callsign will <em>ensure</em> it is unique.") if $foundHost == 1;
+        }
     }
     else
     {

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -315,7 +315,7 @@ foreach $val (@list)
         if($olsrFile) {
           open(my $hostFile, "<", "/var/run/hosts_olsr");
           while(<$hostFile>) {
-            if($_ =~ /\t$host\t/) {
+            if($_ =~ /\s$host\s/i) {
               $foundHost = 1;
               last;
             }

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -323,7 +323,7 @@ foreach $val (@list)
           close($hostFile);
           push(@dhcp_err, "$val <font color='red'>Warning!</font> '$host' is already in use!<br>" .
             "Please choose another hostname.<br>" .
-            "Prefixing the hostname with your callsign will <em>ensure</em> it is unique.") if $foundHost == 1;
+            "Prefixing the hostname with your callsign will help prevent duplicates on the network.") if $foundHost == 1;
         }
     }
     else

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -284,10 +284,28 @@ foreach $val (@list)
     $host = $parms{"dhcp${val}_host"};
     $ip   = $parms{"dhcp${val}_ip"};
     $mac  = $parms{"dhcp${val}_mac"};
-
+    $foundHost = 0;
     if($val eq "_add")
     {
-	next unless ($host or $ip or $mac) and ($parms{dhcp_add} or $parms{button_save});
+	if($host) {
+		#my $foundHost = 0;
+		my $olsrFile = 0;
+        	$olsrFile = 1 if -f "/var/run/hosts_olsr";
+        	if($olsrFile) {
+			open(my $hostFile, "<", "/var/run/hosts_olsr");
+			while(<$hostFile>) {
+            			if($_ =~ /\s$host\s/i) {
+					$foundHost = 1;
+              				last;
+            			}
+          		}
+         		close($hostFile);
+         		push(@dhcp_err, "$val <font color='red'>Warning!</font> '$host' is already in use!<br>" .
+         		"Please choose another hostname.<br>" .
+            		"Prefixing the hostname with your callsign will help prevent duplicates on the network.") if $foundHost == 1;
+        	}
+	}
+	next unless ($host or $ip or $mac or $foundHost) and ($parms{dhcp_add} or $parms{button_save});
     }
     else
     {
@@ -302,29 +320,15 @@ foreach $val (@list)
 
     if(validate_hostname($host))
     {
-        push(@dhcp_err, "$val hostname '$host' is already in use") if (lc $host eq lc $node || lc $host eq lc $tactical);
-        foreach my $key (keys %hosts) {
-            if ( lc $key eq lc $host ){
-                push(@dhcp_err, "$val hostname '$host' is already in use");
-                last;
-            }
-        }
-        my $olsrFile = 0;
-        $olsrFile = 1 if -f "/var/run/hosts_olsr";
-        my $foundHost = 0;
-        if($olsrFile) {
-          open(my $hostFile, "<", "/var/run/hosts_olsr");
-          while(<$hostFile>) {
-            if($_ =~ /\s$host\s/i) {
-              $foundHost = 1;
-              last;
-            }
-          }
-          close($hostFile);
-          push(@dhcp_err, "$val <font color='red'>Warning!</font> '$host' is already in use!<br>" .
-            "Please choose another hostname.<br>" .
-            "Prefixing the hostname with your callsign will help prevent duplicates on the network.") if $foundHost == 1;
-        }
+	if(! $foundHost) {
+		push(@dhcp_err, "$val hostname '$host' is already in use") if (lc $host eq lc $node || lc $host eq lc $tactical);
+        	foreach my $key (keys %hosts) {
+           		if ( lc $key eq lc $host ){
+               			push(@dhcp_err, "$val hostname '$host' is already in use");
+               			last;
+           		}
+        	}
+	}
     }
     else
     {


### PR DESCRIPTION
fixes #216
*additional check for existing hostname when creating new DHCP lease.
checks hosts_olsr file if entered hostname already exists or not on the connected network(s).
outputs info saying such and gives advice to prefix hostname with callsign.