### PR TITLE
bugfix: correct improper "wrong firmware" message on Rocket

### DIFF
--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -136,6 +136,8 @@ if($hardwaretype eq "nanostation-m")
     } elsif($hwmodel =~ /CPE510/i) {
         $hardwaretypev= "510-520-v1" ;      # CPE510 V1.0/v1.1/v2.0
     } 
+} else {
+    $hardwaretypev=$hardwaretype;
 }
 
 # refresh fw


### PR DESCRIPTION
was not properly setting the hardwaretypev variable on some devices