### PR TITLE
aredn: enable nano-m-xw switch to be a dumb switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ only. Depending on deployed usage, 2 cat5 cables may be needed.
 
 The following devices have enhanced Ethernet port usage.  A single cat5 to the device
 could be plugged into ether the 'main' or 'secondary' port with standard port functionality.
-However, if both ports are used, a LAN device on one port is unable to communicate with a LAN
-device on the other port.  If another mesh node is connected to the secondary port, Then 
-the LAN DHCP should be turned off on that node to avoid IP address failures.
+Both ports can be used interchangeably and simultaneously with LAN devices on both ports
+at the same time. POE PassThough can be turned on in Advanced Settings to power ipCams or
+other mesh nodes.
 
 * NanoStation M5 XW
 * NanoStation M2 XW

--- a/patches/711-nano-xw-switch-config.patch
+++ b/patches/711-nano-xw-switch-config.patch
@@ -1,0 +1,18 @@
+Index: openwrt/target/linux/ar71xx/patches-4.9/903-phy-ar8216-no-vlan-ports.patch
+===================================================================
+--- /dev/null
++++ openwrt/target/linux/ar71xx/patches-4.9/903-phy-ar8216-no-vlan-ports.patch
+@@ -0,0 +1,13 @@
++--- a/drivers/net/phy/ar8216.c
+++++ b/drivers/net/phy/ar8216.c
++@@ -1154,7 +1154,9 @@
++ 			if (i == AR8216_PORT_CPU)
++ 				continue;
++ 
++-			portmask[i] = 1 << AR8216_PORT_CPU;
+++			for (j = 0; j < dev->ports; j++) {
+++				portmask[i] |= (1 << j);
+++			}
++ 			portmask[AR8216_PORT_CPU] |= (1 << i);
++ 		}
++ 	}

--- a/patches/series
+++ b/patches/series
@@ -14,3 +14,4 @@
 708-define-aredn-networks.patch
 709-iperf-fw-restart.patch
 710-no-ping6-traceroute6.patch
+711-nano-xw-switch-config.patch


### PR DESCRIPTION
Config the NanoStation M2/M5 XW devices to be fully
functional with a standard aredn port definition.
The vlans are not configured in the switch, rather
acting like a dumb swtich, enabling tagged and untagged
packets to exist on the same switch port at the same time.
This commit enables the ports on the switch to directly
send all traffic to all other ports when not configured
directly in vlan mode.