### PR TITLE
aredn: harden hAP ac lite 5Ghz Lan Access Point

### DIFF
--- a/files/usr/local/bin/wifi-setup
+++ b/files/usr/local/bin/wifi-setup
@@ -115,10 +115,14 @@ for _dev in /sys/class/ieee80211/*; do
     chanbw=""
     country=""
     distance=""
-    ssid="${wifi2_ssid}"
+    ssid=$(echo "${wifi2_ssid}" | sed -e 's/\(..\)/\\x\1/g')
+    ssid=$(echo -e "${ssid}")
+    ssid=${ssid//\"/\\\"}
     mode="ap"
     encryption="${wifi2_encryption}"
-    key="${wifi2_key}"
+    key=$(echo "${wifi2_key}" | sed -e 's/\(..\)/\\x\1/g')
+    key=$(echo -e "${key}")
+    key=${key//\"/\\\"}
     network="lan"
   fi
 
@@ -137,9 +141,9 @@ for _dev in /sys/class/ieee80211/*; do
     set wireless.@wifi-iface[${ifacenum}].device=${radio}         
     set wireless.@wifi-iface[${ifacenum}].network=${network}      
     set wireless.@wifi-iface[${ifacenum}].mode=${mode}            
-    set wireless.@wifi-iface[${ifacenum}].ssid=${ssid}               
+    set wireless.@wifi-iface[${ifacenum}].ssid="${ssid}"               
     set wireless.@wifi-iface[${ifacenum}].encryption=${encryption}       
-    set wireless.@wifi-iface[${ifacenum}].key=${key}
+    set wireless.@wifi-iface[${ifacenum}].key="${key}"
 EOF
   uci -c ${dropdir} -q commit wireless
 

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -111,6 +111,8 @@ else
 	{
 	    eval (sprintf "\$$_ = \"%s\"", quotemeta $cfg{$_});
 	}
+	$wifi2_key =~ s/([a-f0-9][a-f0-9])/chr(hex($1))/eg;
+	$wifi2_ssid =~ s/([a-f0-9][a-f0-9])/chr(hex($1))/eg;
     }
 }
 
@@ -437,9 +439,13 @@ if($parms{button_save})
 	push (@errors, "LAN Access Point SSID must be 32 or less characters ");
     }
 
-    if( "$wifi2_encryption" != "none" and (length( $wifi2_key ) < 8 or length($wifi2_key) > 64) )
+    if( "$wifi2_enable" eq "1" and (length( $wifi2_key ) < 8 or length($wifi2_key) > 64) )
     {
 	push (@errors, "LAN Access Point Password must be at least 8 charaters, up to 64");
+    }
+    if( "$wifi2_enable" eq "1" and ( $wifi2_key =~ /\'/ or $wifi2_ssid =~ /\'/ ))
+    {
+	push (@errors, "The password and ssid may not contain a single quote character.");
     }
 
     if($debug == 3) # don't save the config, just validate it
@@ -452,6 +458,8 @@ if($parms{button_save})
 	$parms{node} = $node;
 	$parms{tactical} = $tactical;
 	system "touch /tmp/unconfigured" if -f "/etc/config/unconfigured";
+	$parms{wifi2_key} =~ s/(.)/sprintf("%x",ord($1))/eg;
+	$parms{wifi2_ssid} =~ s/(.)/sprintf("%x",ord($1))/eg;
 	$rc = save_setup("/etc/config.mesh/_setup");
 	$rc2 = &uci_commit("system");
 	if(-s "/tmp/web/save/node-setup.out")
@@ -859,13 +867,11 @@ if ( $phycount > 1 ) {
 
     print "<tr><td>Encryption</td>\n";
     print "<td><select name=wifi2_encryption>\n";
-    selopt("none", "none", $wifi2_encryption);
     selopt("WPA2 PSK", "psk2", $wifi2_encryption);
     selopt("WPA PSK", "psk", $wifi2_encryption);
-    selopt("WEP" , "wep", $wifi2_encryption);
     print "</select></td></tr>\n";
     print "<tr><td>Password</td>\n";
-    print "<td><input type=text size=15 name=wifi2_key value='$wifi2_key'>";
+    print "<td><input type=password size=15 name=wifi2_key value='$wifi2_key'>";
     print "</td></tr>\n";
 }
 

--- a/files/www/help.html
+++ b/files/www/help.html
@@ -380,12 +380,16 @@ self explanatory.  The <b>LAN Mode</b> is described in the next section.
 
 <p>
 The <strong>LAN Access Point</strong> section will appear on the hAP ac
-lite device. Configure similiar to a typical home access point. DFS channels
+lite device. Configure similar to a typical home access point. DFS channels
 are currently not selectable. Access Points must detect Doppler Radar signals
 and dynamically move to a clear channel for part 15 compliance.  This capability
 and channels may be added in a future image.  Clients connecting to the LAN Access
 Point share the IP Address range with clients attached though the physical Ethernet
-ports.</p>
+ports.<br><br>The Encryption option 'none' is not given to enable operator control
+of who is connecting to the mesh network and manage compliance of part 97
+obligations.<br><br>The password key length must be between 8 and 63 characters.
+If the key is 64 characters, it is treated as hex encoded. A single quote character
+may not be used.</p>
 
 <p>
 The <strong>WAN</strong> box contains the settings used to


### PR DESCRIPTION
enable passwords with virtually any character,  enable SSIDs
with virtually any character.  ensure ap is always
encrypted to give operator control of client access and
license compliance.  Remove (week) WEP encryption option.