### PR TITLE
aredn: Standardize Ethernet Port vlans for UBNT XM devices

### DIFF
--- a/files/etc/config.mesh/network
+++ b/files/etc/config.mesh/network
@@ -18,8 +18,9 @@ config interface lan
 include /etc/aredn_include/ethmacfixup
 
 #### WAN configuration
-config interface	wan
+config interface wan
 	option ifname	"<wan_intf>"
+include /etc/aredn_include/nanostation-xm
 	option proto	<wan_proto>
 	option ipaddr	<wan_ip>
 	option netmask	<wan_mask>
@@ -36,6 +37,7 @@ config interface wifi
 #### device to device configuration
 config interface dtdlink
         option ifname   "<dtdlink_intf>"
+include /etc/aredn_include/nanostation-xm
         option proto    static
         option ipaddr   <dtdlink_ip>
         option netmask  255.0.0.0

--- a/files/etc/init.d/local
+++ b/files/etc/init.d/local
@@ -8,8 +8,9 @@ boot() {
   then
     mkdir -p /etc/aredn_include
     touch /etc/aredn_include/ethmacfixup
-    local lanintf=`uci -q get 'network.lan.ifname'`
-    local wifiintf=`uci -q get 'network.wifi.ifname'`
+    local lanintf="$(uci -q get 'network.lan.ifname')"
+    lanintf=${lanintf%% *}
+    local wifiintf="$(uci -q get 'network.wifi.ifname')"
     local lanmac=`ifconfig $lanintf | grep -o -E '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}'`
     local wifimac=`ifconfig $wifiintf | grep -o -E '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}'`
 

--- a/files/etc/uci-defaults/99_setup_aredn_include
+++ b/files/etc/uci-defaults/99_setup_aredn_include
@@ -148,4 +148,10 @@ if [ ! -s /etc/aredn_include/system_netled ]; then
 fi
 fi
 
+hwtype="$('/usr/local/bin/get_hardwaretype')"
+touch /etc/aredn_include/nanostation-xm
+if [ ! -f /etc/aredn_include/nanostation-m -a "$hwtype" = "nanostation-m" ]; then
+	echo "	option	type	'bridge'" > /etc/aredn_include/nanostation-xm
+fi
+
 exit 0

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -67,7 +67,7 @@ usage() unless defined $config;
 
 die "'$config' is not a valid configuration\n" unless ($config eq "mesh" and -f "/etc/config.mesh/_setup");
 
-chomp ($lanintf=`jsonfilter -e '@.network.lan.ifname' < /etc/board.json`);
+chomp ($lanintf=`jsonfilter -e '@.network.lan.ifname' < /etc/board.json | cut -f1`);
 $node = nvram_get("node");
 $tactical = nvram_get("tactical");
 $mac2 = mac2ip(get_mac(get_interface("wifi")), 0);
@@ -123,13 +123,14 @@ foreach $line (`cat /etc/config.mesh/_setup`)
   $cfg{$1} = $2;
 }
 
-$cfg{"lan_intf"} = $lanintf;
+chomp ($lanintf=`jsonfilter -e '@.network.lan.ifname' < /etc/board.json`);
+$cfg{"lan_intf"} = "$lanintf";
 if ( ! $cfg{"wifi_intf"} )
 {
   $cfg{"wifi_intf"} = get_interface("wifi");
 }
-$cfg{"wan_intf"} = get_interface("wan");
-$cfg{"dtdlink_intf"} = get_interface("dtdlink");
+$cfg{"wan_intf"} = get_bridge_interfaces("wan");
+$cfg{"dtdlink_intf"} = get_bridge_interfaces("dtdlink");
 
 $cfg{"wifi_intf"} =~ /wlan(\d+)/;
 

--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -1708,6 +1708,33 @@ sub get_interface
   }
 }
 
+sub get_bridge_interfaces
+{
+  my ($intf) = @_;
+  my $bridge = `uci -q get network.$intf.type`;
+  my $intfname = `uci -q get network.$intf.ifname`;
+  chomp $intfname;
+
+  if ($intfname) {
+    return $intfname;
+  } else {
+    # guess at most common interface options
+    if ( $intf eq "lan" )
+    {
+      return "eth0";
+    } elsif ( $intf eq "wan" ){
+      return "eth0.1";
+    } elsif ( $intf eq "wifi" ){
+      return "wlan0";
+    } elsif ( $intf eq "dtdlink" ){
+      return "eth0.2";
+    } else {
+      # we have a problem
+      die("Unknown interface in call to get_interface");
+    }
+  }
+}
+
 sub reboot_required()
 {
   http_header();

--- a/patches/708-define-aredn-networks.patch
+++ b/patches/708-define-aredn-networks.patch
@@ -99,14 +99,14 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
 -		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
 +		ucidef_set_interface_wan "eth0"
 +		ucidef_set_interface_raw "wifi" "wlan0" "static"
- 		ucidef_add_switch "switch0" \
--			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
++		ucidef_add_switch "switch0" \
 +			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4t:unused" "4t:dtdlink"
 +		;;
 +	rb-952ui-5ac2nd)
 +		ucidef_set_interface_wan "eth0"
 +		ucidef_set_interface_raw "wifi" "wlan1" "static"
-+		ucidef_add_switch "switch0" \
+ 		ucidef_add_switch "switch0" \
+-			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 +		"0@eth1" "4:lan:1" "3:lan:2" "2:lan:3" "1t:unused" "1t:dtdlink"
  		;;
  	all0258n|\
@@ -172,9 +172,16 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  		;;
  	rb-493g)
  		ucidef_set_interfaces_lan_wan "eth0.1 eth1.1" "eth1.2"
-@@ -567,7 +582,9 @@ ar71xx_setup_interfaces()
+@@ -566,8 +581,16 @@ ar71xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
  			"0@eth0" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4" "5:wan"
  		;;
++	nanostation-m)
++		ucidef_set_interface_lan "eth0 eth1"
++		ucidef_set_interface_wan "eth0.1 eth1.1"
++		ucidef_set_interface_raw "dtdlink" "eth0.2 eth1.2" "static"
++		ucidef_set_interface_raw "wifi" "wlan0" "static"
++		;;
  	*)
 -		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 +		ucidef_set_interface_raw "wifi" "wlan0" "static"


### PR DESCRIPTION
The secondary port on Ubnt XM devices was non-functional.
Enabled bridge type in network config to utilize both ports.