### PR TITLE
bugfix: advanced config usb passthru errors 

### DIFF
--- a/files/etc/config.mesh/aredn
+++ b/files/etc/config.mesh/aredn
@@ -3,7 +3,10 @@ config downloads
 
 config poe
 		option passthrough '0'
-        
+
+config usb
+		option passthrough '1'
+
 config map
         option leafletjs 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js'
         option leafletcss 'http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css'


### PR DESCRIPTION
erros when aredn.usb uci section is not available