### PR TITLE
aredn: hap ac lite add 2G/5G lan ap options

### DIFF
--- a/files/etc/config.mesh/_setup
+++ b/files/etc/config.mesh/_setup
@@ -15,6 +15,7 @@ wifi2_ssid = NoCall-AREDN
 wifi2_channel = 36
 wifi2_encryption =
 wifi2_key = 
+wifi2_hwmode = 11a
 
 dmz_mode = 3
 lan_proto = static

--- a/files/etc/config.mesh/_setup.default
+++ b/files/etc/config.mesh/_setup.default
@@ -15,6 +15,7 @@ wifi2_ssid = NoCAll-AREDN
 wifi2_channel = 36
 wifi2_encryption = none
 wifi2_key = 
+wifi2_hwmode = 11a
 
 dmz_mode = 3
 lan_proto = static

--- a/files/usr/local/bin/wifi-setup
+++ b/files/usr/local/bin/wifi-setup
@@ -52,11 +52,11 @@ done < $configfile
 
 meshif="$(uci -q get network.wifi.ifname)"
 meshphy="phy${meshif#wlan}"
-hwtype="$(/usr/local/bin/get_hardwaretype)"
 
 rm -f "${dropdir}/wireless" 
 touch "${dropdir}/wireless"
 
+ifacecount=$(ls -d /sys/class/ieee80211/* | wc -l)
 ifacenum=0
 
 # find each phy and configure in wirelss config 
@@ -82,12 +82,6 @@ for _dev in /sys/class/ieee80211/*; do
     dev_id="set wireless.${radio}.macaddr=$(cat /sys/class/ieee80211/${dev}/macaddress)"
   fi
 
-  if [ $wifi2_enable -eq 1 ]; then
-    wifi2_disabled="0"
-  else
-    wifi2_disabled="1"
-  fi
-
   is_mesh_rf=0
   hwmode="11g"
   htmode="HT20"
@@ -95,6 +89,12 @@ for _dev in /sys/class/ieee80211/*; do
   iw phy "${dev}" info | grep -q '5180 MHz' && {
     hwmode="11a"
   }
+
+  if [[  $wifi2_enable -eq 1 -a \( $ifacecount -eq 1 -o \( \( $ifacecount -gt 1 \) -a \( "$hwmode" = "$wifi2_hwmode" \) \) \) ]] ; then
+    wifi2_disabled="0"
+  else
+    wifi2_disabled="1"
+  fi
 
   if [ "${dev}" = "${meshphy}" ]; then
     # mesh RF adhoc configuration
@@ -126,40 +126,37 @@ for _dev in /sys/class/ieee80211/*; do
     network="lan"
   fi
 
-  # test for devices with 2 wireless cards -- don't setup 2 APs
-  if [ "$hwtype" != "rb-952ui-5ac2nd" -o "$hwmode" != "11g" -o ${is_mesh_rf} -eq 1 ]; then
-    uci -c ${dropdir} -q batch > /dev/null <<-EOF
-      set wireless.${radio}=wifi-device
-      set wireless.${radio}.type=mac80211
-      set wireless.${radio}.disabled=${disabled}
-      set wireless.${radio}.channel=${channel}
-      set wireless.${radio}.chanbw=${chanbw}
-      set wireless.${radio}.country=${country}
-      set wireless.${radio}.distance=${distance}
-      set wireless.${radio}.hwmode=${hwmode}
-      set wireless.${radio}.htmode=${htmode}
-      ${dev_id}
-      add wireless wifi-iface
-      set wireless.@wifi-iface[${ifacenum}].device=${radio}         
-      set wireless.@wifi-iface[${ifacenum}].network=${network}      
-      set wireless.@wifi-iface[${ifacenum}].mode=${mode}            
-      set wireless.@wifi-iface[${ifacenum}].ssid="${ssid}"               
-      set wireless.@wifi-iface[${ifacenum}].encryption=${encryption}       
-      set wireless.@wifi-iface[${ifacenum}].key="${key}"
+  uci -c ${dropdir} -q batch > /dev/null <<-EOF
+    set wireless.${radio}=wifi-device
+    set wireless.${radio}.type=mac80211
+    set wireless.${radio}.disabled=${disabled}
+    set wireless.${radio}.channel=${channel}
+    set wireless.${radio}.chanbw=${chanbw}
+    set wireless.${radio}.country=${country}
+    set wireless.${radio}.distance=${distance}
+    set wireless.${radio}.hwmode=${hwmode}
+    set wireless.${radio}.htmode=${htmode}
+    ${dev_id}
+    add wireless wifi-iface
+    set wireless.@wifi-iface[${ifacenum}].device=${radio}         
+    set wireless.@wifi-iface[${ifacenum}].network=${network}      
+    set wireless.@wifi-iface[${ifacenum}].mode=${mode}            
+    set wireless.@wifi-iface[${ifacenum}].ssid="${ssid}"               
+    set wireless.@wifi-iface[${ifacenum}].encryption=${encryption}       
+    set wireless.@wifi-iface[${ifacenum}].key="${key}"
 EOF
-    uci -c ${dropdir} -q commit wireless
+  uci -c ${dropdir} -q commit wireless
 
-    if [ ${is_mesh_rf} -eq 1 ]; then
-      # add monitor interface on mesh rf
-      ifacenum=$((ifacenum + 1))
-      uci -c ${dropdir} -q batch > /dev/null <<-EOF
-        add wireless wifi-iface
-        set wireless.@wifi-iface[${ifacenum}].device=${radio}
-        set wireless.@wifi-iface[${ifacenum}].network=wifi_mon
-        set wireless.@wifi-iface[${ifacenum}].mode=monitor
+  if [ ${is_mesh_rf} -eq 1 ]; then
+    # add monitor interface on mesh rf
+    ifacenum=$((ifacenum + 1))
+    uci -c ${dropdir} -q batch > /dev/null <<-EOF
+      add wireless wifi-iface
+      set wireless.@wifi-iface[${ifacenum}].device=${radio}
+      set wireless.@wifi-iface[${ifacenum}].network=wifi_mon
+      set wireless.@wifi-iface[${ifacenum}].mode=monitor
 EOF
-      uci -q -c ${dropdir} commit wireless
-    fi
+    uci -q -c ${dropdir} commit wireless
   fi
  
   ifacenum=$((ifacenum + 1))

--- a/files/www/cgi-bin/setup
+++ b/files/www/cgi-bin/setup
@@ -448,6 +448,20 @@ if($parms{button_save})
 	push (@errors, "The password and ssid may not contain a single quote character.");
     }
 
+    if ( $wifi2_channel < 30 and "$wifi2_hwmode" eq "11a" )
+    {
+        push (@errors, "Changed to 5GHz Mesh LAN AP, please review channel selection");
+    }
+    if ( $wifi2_channel > 30 and "$wifi2_hwmode" eq "11g" )
+    {
+        push (@errors, "Changed to 2GHz Mesh LAN AP, please review channel slection");
+    }
+    if ( $phycount > 1 and $wifi_enable and $wifi2_channel < 36 and $wifi2_enable )
+    {
+	push (@errors, "Mesh RF and LAN Access Point can not both use the same wireless card, review LAN AP settings");
+    }
+	
+
     if($debug == 3) # don't save the config, just validate it
     {
 	push (@errors, "OK") unless @errors;
@@ -677,8 +691,15 @@ print "<table cellpadding=5 border=1 width=100%><tr><td valign=top width=33%>\n"
 # MESH RF settings
 #
 
-print "<table width=100% style='border-collapse: collapse;'>
-<tr><th colspan=2>Mesh RF</th></tr>";
+print "<table width=100% style='border-collapse: collapse;'>";
+if ( $phycount > 1 )
+    {
+	print " <tr><th colspan=2>Mesh RF (2GHz)</th></tr>";
+    }
+    else
+    {
+        print " <tr><th colspan=2>Mesh RF</th></tr>";
+    }
 
 push @hidden, "<input type=hidden name=wifi_proto value='static'>";
 
@@ -855,25 +876,43 @@ else
 
 print "<tr><td colspan=2><hr></hr></td></tr>";
 
-if ( $phycount > 1 or ! $wifi_enable ) {
+$M39model = `/usr/local/bin/get_model | grep -e "M[39]"`;
+if ( $phycount > 1 or ! $wifi_enable and ! $M39model )
+{
 
-    # determine AP's band
-    if ( "$phy" eq "phy0" ) { $APphy="phy1"; }
+    if ( $wifi_enable and "$wifi2_hwmode" eq "11g" )
+    {
+	$wifi2_hwmode = "11a";
+	if ( $wifi2_channel < 36 )
+	{
+	    $wifi2_channel = 36;
+	}
+    }
+
+    # determine AP's wireless phy
+    if ( "$wifi2_hwmode" eq "11g"  and ! $wifi_enable )
+    { $APphy="phy1"; }
     else { $APphy="phy0"; }
+
     $rc3 = system("iw phy ${APphy} info | grep -q '5180 MHz' > /dev/null");
     undef @chan;
-    if ( $rc3 ) {
-	@chan=@ctwo;
-    }
-    else {
-	@chan=@cfive;
-    }
+    if ( $rc3 ) { @chan=@ctwo; } else { @chan=@cfive; }
 
     print "<tr><th colspan=2>LAN Access Point</th></tr>";
     print "<tr><td>Enable</td>";
     print "<td><input type=checkbox name=wifi2_enable value=1";
     print " checked" if $wifi2_enable;
     print "></td></tr>\n";
+
+    if ( $phycount > 1 ) {
+	print "<tr><td>AP band</td>\n";
+	print "<td><select name=wifi2_hwmode>\n";
+	if ( ! $wifi_enable ) {
+	    selopt("2GHz", "11g", $wifi2_hwmode);
+	}
+	selopt("5GHz", "11a", $wifi2_hwmode);
+	print "</select></td></tr>\n";
+    }
 
     print "<tr><td>SSID</td>\n";
     print "<td><input type=text size=15 name=wifi2_ssid value='$wifi2_ssid'></td></tr>\n";
@@ -889,8 +928,8 @@ if ( $phycount > 1 or ! $wifi_enable ) {
 
     print "<tr><td>Encryption</td>\n";
     print "<td><select name=wifi2_encryption>\n";
-    selopt("WPA2 PSK", "psk2", $wifi2_encryption);
-    selopt("WPA PSK", "psk", $wifi2_encryption);
+	selopt("WPA2 PSK", "psk2", $wifi2_encryption);
+	selopt("WPA PSK", "psk", $wifi2_encryption);
     print "</select></td></tr>\n";
     print "<tr><td>Password</td>\n";
     print "<td><input type=password size=15 name=wifi2_key value='$wifi2_key'>";
@@ -903,6 +942,7 @@ else
     push @hidden, "<input type=hidden name=wifi2_key        value='$wifi2_key'>";
     push @hidden, "<input type=hidden name=wifi2_channel    value='$wifi2_channel'>";
     push @hidden, "<input type=hidden name=wifi2_encryption value='$wifi2_encryption'>"; 
+    push @hidden, "<input type=hidden name=wifi2_hwmode     value='$wifi2_hwmode'>"; 
 }
 
 if(0) # disable for now


### PR DESCRIPTION
Add option for hap ac lite to select which band to
use for LAN AP option, 2GHz or 5GHz.  Also, ensure
all wireless cards are defined when disabled to
prevent default wireless config options.