### PR TITLE
bugfix: aredn: fix bogus nano-m-xw image upload warning

### DIFF
--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -121,7 +121,9 @@ if($mfg=~ /Ubiquiti/i)
 
 if(${hardwaretype} eq "nanostation-m")
 {
-    ${hardwaretypev}="nano-m";
+    ${hardwaretypev}="nano-m"; # Nano XM
+} elsif(${hardwaretype} eq "nanostation-m-xw") {
+    ${hardwaretypev}= "nano-m-xw" ; # Nano XW
 } elsif(${hardwaretype} eq "rb-952ui-5ac2nd") {
     ${hardwaretypev}= "rb-nor-flash-16M-ac" ;    # hAP AC Lite
 } elsif(${hardwaretype} =~ /rb-911g-[25]hpnd/i or


### PR DESCRIPTION
fixes #330