### PR TITLE
aredn: olsrd: add olsrd watchdog

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -63,6 +63,7 @@ CONFIG_PACKAGE_olsrd-mod-nameservice=y
 CONFIG_PACKAGE_olsrd-mod-txtinfo=y
 CONFIG_PACKAGE_olsrd-mod-jsoninfo=y
 CONFIG_PACKAGE_olsrd-mod-dot-draw=y
+CONFIG_PACKAGE_olsrd-mod-watchdog=y
 CONFIG_PACKAGE_olsrd-mod-secure=y
 CONFIG_PACKAGE_perlbase-essential=y
 CONFIG_PACKAGE_perlbase-xsloader=y

--- a/files/etc/config.mesh/olsrd
+++ b/files/etc/config.mesh/olsrd
@@ -29,6 +29,11 @@ config LoadPlugin
 	option accept '127.0.0.1'
 	option port '2003'
 
+config LoadPlugin
+	option library 'olsrd_watchdog.so.0.1'
+	option file '/tmp/olsrd.watchdog'
+	option interval '5'
+
 config Interface
 	list interface 'wifi'
 

--- a/files/etc/permpkg
+++ b/files/etc/permpkg
@@ -63,6 +63,7 @@ olsrd-mod-httpinfo
 olsrd-mod-nameservice
 olsrd-mod-secure
 olsrd-mod-txtinfo
+olsrd-mod-watchdog
 opkg
 perl
 perlbase-essential

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -433,6 +433,7 @@ unless($cfg{wifi_proto} eq "disabled")
   {
     printf FILE "echo %s,%s > /tmp/latlon.txt\n", $cfg{aprs_lat}, $cfg{aprs_lon};
   }
+  print FILE "/usr/local/bin/olsrd-watchdog &\n";
   print FILE "/usr/local/bin/olsrd-namechange-loop &\n";
 }
 close(FILE);

--- a/files/usr/local/bin/olsrd-watchdog
+++ b/files/usr/local/bin/olsrd-watchdog
@@ -1,0 +1,75 @@
+#!/bin/sh
+true <<'LICENSE'
+  Part of AREDN -- Used for creating Amateur Radio Emergency Data Networks
+  Copyright (C) 2019 Joe Ayers AE6XE
+  See Contributors file for additional contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional Terms:
+
+  Additional use restrictions exist on the AREDN(TM) trademark and logo.
+    See AREDNLicense.txt for more info.
+
+  Attributions to the AREDN Project must be retained in the source code.
+  If importing this code into a new or existing project attribution
+  to the AREDN project must be added to the source code.
+
+  You must not misrepresent the origin of the material contained within.
+
+  Modified versions must be modified to attribute to the original source
+  and be marked in reasonable ways as differentiate it from the original
+  version.
+
+LICENSE
+
+pidfile="/var/run/olsrd.pid"
+logfile="/tmp/olsrd.log"
+
+olsrd_restart()
+{
+  uptime=$(cut -d' ' -f1 < /proc/uptime)
+  date=$(date)
+  echo "$uptime $date" >> $logfile
+  /etc/init.d/olsrd restart
+
+  # keep file size in check
+  if [ $(wc -l $logfile | cut -d\  -f1 ) -gt 300 ] ; then
+    cp  $logfile $logfile.tmp
+    tail -275 $logfile.tmp > $logfile
+    rm -f $logfile.tmp
+  fi
+} 
+ 
+touch $logfile
+
+while true
+do
+
+  sleep 21
+
+  if [ -f $pidfile -a -d "/proc/$(cat $pidfile 2>/dev/null)" ] ; then
+    if [ -f /tmp/olsrd.watchdog ] ; then
+      rm -f /tmp/olsrd.watchdog
+    else
+      # olsrd is running, but not processing events
+      olsrd_restart
+    fi
+  else
+    olsr_pid=$(ps | grep /usr/sbin/olsrd | grep -v grep | sed -e "s/^ //" | cut -d\  -f1 )
+    [ ! $olsr_pid ] && olsr_pid=0
+    [ ! -f $pidfile -a $olsr_pid -gt 1 ]  &&  echo -n "$olsr_pid" > $pidfile
+  fi
+
+done
+

--- a/files/usr/local/bin/uploadctlservices
+++ b/files/usr/local/bin/uploadctlservices
@@ -28,7 +28,7 @@ start_upgrade_mode() {
     /usr/local/bin/linkled upgrade
 
     # Purge the /tmp/ filesystem of unneeded files.
-    rm -Rf /tmp/node.history /tmp/snrlog/ /tmp/snr.dat /tmp/web/firmware.list /tmp/.uci
+    rm -Rf /tmp/node.history /tmp/olsrd.log /tmp/olsrd.watchdog /tmp/snrlog/ /tmp/snr.dat /tmp/web/firmware.list /tmp/.uci
 
 }
 

--- a/files/www/cgi-bin/supporttool
+++ b/files/www/cgi-bin/supporttool
@@ -53,6 +53,7 @@ $phy=get_wlan2phy("${wifiif}");
            "/tmp/rssi.dat",
            "/tmp/rssi.log",
            "/tmp/zombie.log",
+           "/tmp/olsrd.log",
             );
 
 @sensitive = ( "/etc/config/vtun",


### PR DESCRIPTION
Adding native olsrd watchdog on top of procd
ensures mesh nodes are always accessable.

closes #338