### PR TITLE
aredn: add definition for hAP ac lite current revision

### DIFF
--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -1110,6 +1110,15 @@ sub hardware_info
       'usechains'       => 1,
       'rfband'          => '2400',
     },
+    'MikroTik RouterBOARD RB952Ui-5ac2nD' => {
+      'name'            => 'MikroTik RouterBOARD RB952Ui-5ac2nD',
+      'comment'         => '',
+      'supported'       => '1',
+      'maxpower'        => '22',
+      'pwroffset'       => '0',
+      'usechains'       => 1,
+      'rfband'          => '2400',
+    },
     'Mikrotik RouterBOARD 912UAG-2HPnD' => {
       'name'            => 'Mikrotik RouterBOARD 912UAG-2HPnD',
       'comment'         => '',

--- a/patches/005-add-haplite-new-model.patch
+++ b/patches/005-add-haplite-new-model.patch
@@ -1,0 +1,14 @@
+Index: openwrt/target/linux/ar71xx/base-files/lib/ar71xx.sh
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ openwrt/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -1106,6 +1106,9 @@ ar71xx_board_detect() {
+ 	*"RouterBOARD 952Ui-5ac2nD")
+ 		name="rb-952ui-5ac2nd"
+ 		;;
++	*"RouterBOARD RB952Ui-5ac2nD")
++		name="rb-952ui-5ac2nd"
++		;;
+ 	*"RouterBOARD 962UiGS-5HacT2HnT")
+ 		name="rb-962uigs-5hact2hnt"
+ 		;;

--- a/patches/series
+++ b/patches/series
@@ -8,6 +8,7 @@
 003-add-winbond-w25q128jv.patch
 004-add-lhg-5hpnd-xl.patch
 004-add-ldf-5nd.patch
+005-add-haplite-new-model.patch
 700-cpe-diags.patch
 701-extended-spectrum.patch
 702-enable-country-hx.patch


### PR DESCRIPTION
/proc/cpuinfo machine string to identify the device
has changed.
From - MikroTik RouterBOARD 952Ui-5ac2nD
To   - MIkroTik RouterBOARD RB952Ui-5ac2nD