### PR TITLE
bugfix: delay start up of snmpd until later in the boot process.

### DIFF
--- a/patches/713-delay-snmpd-startup.patch
+++ b/patches/713-delay-snmpd-startup.patch
@@ -1,0 +1,12 @@
+Index: openwrt/feeds/packages/net/net-snmp/files/snmpd.init
+===================================================================
+--- openwrt.orig/feeds/packages/net/net-snmp/files/snmpd.init
++++ openwrt/feeds/packages/net/net-snmp/files/snmpd.init
+@@ -1,6 +1,6 @@
+ #!/bin/sh /etc/rc.common
+ # Copyright (C) 2008 OpenWrt.org
+-START=50
++START=98
+ 
+ USE_PROCD=1
+ PROG="/usr/sbin/snmpd"

--- a/patches/series
+++ b/patches/series
@@ -22,3 +22,4 @@
 710-no-ping6-traceroute6.patch
 711-nano-xw-switch-config.patch
 712-auto-distance-settings.patch
+713-delay-snmpd-startup.patch


### PR DESCRIPTION
On some devices snmpd would start before it's configuration file was created.

Changed /etc/rc.d/S50snmpd to /etc/rc.d/S98snmpd

Fixes #374 