### PR TITLE
readme: updated with hAP AC Lite port info

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ other mesh nodes.
 * NanoStation M3 XM
 * NanoStation M5 XM
 
+The Mikrotik hAP ac lite is pre-configured with the following VLANs:
+
+* Port 1: VLAN 1 (untagged) WAN connection between AREDN network and an external network such as the Internet.
+* Port 5: VLAN 2 for DtD linking of another node with the _Mikrotik hAP ac lite_.
+* Ports 2-4: no VLAN tagging, for devices connecting to the _Mikrotik hAP ac lite_ local LAN address space.
+
 ## Submitting Bug Reports
 
 Please submit all issues to http://github.com/aredn/aredn_ar71xx/issues

--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ other mesh nodes.
 * NanoStation M3 XM
 * NanoStation M5 XM
 
-The Mikrotik hAP ac lite is pre-configured with the following VLANs:
+The Mikrotik hAP AC Lite, Ubiquiti AirRouter, and AirRouter HP are pre-configured with the following VLANs:
 
-* Port 1: VLAN 1 (untagged) WAN connection between AREDN network and an external network such as the Internet.
-* Port 5: VLAN 2 for DtD linking of another node with the _Mikrotik hAP ac lite_.
-* Ports 2-4: no VLAN tagging, for devices connecting to the _Mikrotik hAP ac lite_ local LAN address space.
+* Port 1: WAN Port - Packets in/out of this port are expected to be untagged. The node is (by default) configured to receive a DHCP assigned address from a home network, internet, or other foreign network.
+* Port 5: DtDLink Port Mesh Routing -- Connect to another mesh node or 8021.q switch. Packets in/out of this port must be vlan 2 tagged, other packets are ignored.
+* Ports 2-4: LAN devices -- Packets in/out of this port are expected to be untagged. The mesh node will (default) DHCP assign an IP address to your computer, ipCam, voip phone, etc. connected to these ports.
 
 ## Submitting Bug Reports
 


### PR DESCRIPTION
added info from KC0EUW and AE6XE regarding the Mikrotik hAP AC Lite ethernet port definitions