### PR TITLE
aredn: Set default channel and width

### DIFF
--- a/files/www/cgi-bin/channelmaps.pm
+++ b/files/www/cgi-bin/channelmaps.pm
@@ -270,15 +270,15 @@ sub rf_default_channel
             channel => "5",
         },
         '2400' => {
-            chanbw  => "20",
-            channel => "1",
+            chanbw  => "10",
+            channel => "-2",
         },
         '3400' => {
-            chanbw  => "5",
+            chanbw  => "10",
             channel => "84",
         },
         '5800ubntus' => {
-            chanbw  => "5",
+            chanbw  => "10",
             channel => "149",
         },
     );


### PR DESCRIPTION
10MHz channel width is most commonly used. This default
will minimize how many new users are unable to connect
to a local mesh on first try.  In 2GHz use ch -2
as only clear part 97 10MHz channel available and
predominently used.