### PR TITLE
Fixed the consistency between "archive" and "realtime" SNR data

### DIFF
--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -98,13 +98,13 @@ function getFreeMemory()
 	return info
 end
 
-function getSignal(realtime) 
+-- gets signal and noise data from either iwinfo (realtime = true) or the files archived in /tmp/snrlog (realtime = false)
+-- the files in /tmp/snrlog are written once per minute by the script /usr/local/bin/snrlog
+function getSignal(realtime)
 	local defnoise=-95
-	local ol={}
 	local dpa={}  -- datapoint table/array
 	local dirname="/tmp/snrlog"
-	local values={}
-	local counter=0
+
 	local datepattern="(%d+)/(%d+)/(%d+)%s(%d+):(%d+):(%d+)"
 
 	local parms={}
@@ -122,70 +122,82 @@ function getSignal(realtime)
 	local radio=aredn_info.getMeshRadioDevice()
 	local bandwidth=aredn_info.getChannelBW(radio)
 
+	local timestamp_s=os.time()
+	local signal_dbm, noise_dbm, tx_rate_mbps, rx_rate_mbps, tx_rate_mcs_index, rx_rate_mcs_index
+
+	--[[
+		-- insertResult() transforms data from iwinfo (realtime) and snrlog (archive) so that the responses are always the same.
+		-- the front end expects data points that look like this:
+		{
+			timestamp: string;
+			signal_dbm: number;
+			noise_dbm: number;
+			tx_rate_mbps: number;
+			rx_rate_mbps: number;
+			tx_rate_mcs_index: number | undefined;
+			rx_rate_mcs_index: number | undefined;
+		}
+	]]--
+
+	function insertResult(timestamp_s_epoch, signal_dbm, noise_dbm, tx_rate_mbps, rx_rate_mbps, tx_rate_mcs_index, rx_rate_mcs_index)
+		local dp={} -- datapoint
+		local timestamp
+
+		-- snrlog sometimes has the string "null" for signal/noise, if so then assume they are zero
+		if signal_dbm=="null" then
+			signal_dbm = 0
+		end
+		if noise_dbm=="null" then
+			noise_dbm = 0
+		end
+
+		-- signal and noise might also be nil, so convert them to numbers
+		signal_dbm = tonumber(signal_dbm or 0)
+		noise_dbm = tonumber(noise_dbm or 0)
+
+		--snrlog sometimes has -1 for mcs indices, if so then make them undefined
+		if tx_rate_mcs_index == -1 or tx_rate_mcs_index == "-1" then
+			tx_rate_mcs_index = nil
+		end
+		if rx_rate_mcs_index == -1 or rx_rate_mcs_index == "-1" then
+			rx_rate_mcs_index = nil
+		end
+
+		-- convert from seconds since epoch to iso 8601 format
+		timestamp=os.date("%Y-%m-%dT%H:%M:%SZ", timestamp_s_epoch)
+
+		dp.timestamp = timestamp
+		dp.signal_dbm=signal_dbm
+		dp.noise_dbm=noise_dbm
+		dp.tx_rate_mbps=tonumber(tx_rate_mbps or 0)
+		dp.rx_rate_mbps=tonumber(rx_rate_mbps or 0)
+		dp.tx_rate_mcs_index=tonumber(tx_rate_mcs_index)
+		dp.rx_rate_mcs_index=tonumber(rx_rate_mcs_index)
+		table.insert(dpa,dp)
+	end
+
 	if realtime then
 		-- REALTIME
-		local d=os.date("%H:%M:%S")
-		local n   -- noise
-		local m   -- margin
-		local s   -- signal
-		local dp={} -- datapoint
-		local yinfo={}
-
 		if (parms.device=="strongest" or parms.device=="" or (not parms.device)) then
 			-- REALTIME/STRONGEST SIGNAL
-			-- get radio noise floor
-			n=iwinfo["nl80211"].noise(wifiiface)
-			if (n < -101 or n > -50) then
-				n=defnoise
-			end
-			-- get strongest signal
-			s=iwinfo["nl80211"].signal(wifiiface)
-			m=tonumber(s)-tonumber(n)
-			if s==0 then
-				s="null"
-			end
-			tx_rate="N/A"
-			rx_rate="N/A"
-			tx_mcs="N/A"
-			rx_mcs="N/A"
-			dp.tx_rate=tx_rate
-			dp.rx_rate=rx_rate
-			dp.tx_mcs=tx_mcs
-			dp.rx_mcs=rx_mcs
+			signal_dbm=iwinfo["nl80211"].signal(wifiiface)
+			noise_dbm=iwinfo["nl80211"].noise(wifiiface)
 		else
 			-- REALTIME/SPECIFIC SIGNAL
 			-- split out device to mac-host
 			local mac,host=string.match(parms.device,"([^-]*)-(.*)")
 			local macinfo=iwinfo["nl80211"].assoclist(wifiiface)[mac:upper()]
-			n=macinfo.noise
-			s=macinfo.signal
-			n=tonumber(n)
-			s=tonumber(s)
-			m=s-n
-			tx_rate=macinfo.tx_rate/1000
-			tx_rate=adjust_rate(tx_rate,bandwidth)
-			rx_rate=macinfo.rx_rate/1000
-			rx_rate=adjust_rate(rx_rate,bandwidth)
-			tx_mcs=macinfo.tx_mcs
-			rx_mcs=macinfo.rx_mcs
-			m=tonumber(s)-tonumber(n)
-		end
 
-		if s==0 then
-			s="null"
+			signal_dbm=macinfo.signal
+			noise_dbm=macinfo.noise
+			tx_rate_mbps=macinfo.tx_rate/1000
+			tx_rate_mbps=adjust_rate(tx_rate_mbps,bandwidth)
+			rx_rate_mbps=macinfo.rx_rate/1000
+			rx_rate_mbps=adjust_rate(rx_rate_mbps,bandwidth)
+			tx_rate_mcs_index=macinfo.tx_mcs
+			rx_rate_mcs_index=macinfo.rx_mcs
 		end
-
-		table.insert(yinfo,s)
-		table.insert(yinfo,n)
-		dp.label=d
-		dp.y=yinfo
-		dp.m=m
-		dp.tx_rate=tx_rate
-		dp.rx_rate=rx_rate
-		dp.tx_mcs=tx_mcs
-		dp.rx_mcs=rx_mcs
-		table.insert(dpa,dp)
-		table.insert(ol,dpa)
+		insertResult(timestamp_s, signal_dbm, noise_dbm, tx_rate_mbps, rx_rate_mbps, tx_rate_mcs_index, rx_rate_mcs_index )
 	else
 		-- ARCHIVE
 		local filename
@@ -202,37 +214,18 @@ function getSignal(realtime)
 
 		if filename then
 			for line in io.lines(filename) do
-				local yinfo={}
-				local dp={}
-				local dt,s,n,tm,tr,rm,rr=line:match("(.*)%,(.*)%,(.*),(.*),(.*),(.*),(.*)")
-				local dtm,dtd,dty,dth,dtmin,dts=dt:match(datepattern)
-				local dtseconds=os.time({month=dtm,day=dtd,year=dty,hour=dth,min=dtmin,sec=dts})
-				dtseconds=dtseconds*1000
-				dtseconds=math.floor(dtseconds)
-				n=tonumber(n)
+				local timestamp
+				timestamp,signal_dbm,noise_dbm,tx_rate_mcs_index,tx_rate_mbps,rx_rate_mcs_index,rx_rate_mbps=line:match("(.*)%,(.*)%,(.*),(.*),(.*),(.*),(.*)")
 
-				if s~="null" then
-					s=tonumber(s)
-					m=s-n
-				else
-					m="N/A"
-				end
-				table.insert(yinfo,s)
-				table.insert(yinfo,n)
-				dp.label=dt
-				dp.x=dtseconds
-				dp.y=yinfo
-				dp.m=m
-				dp.tx_rate=tr
-				dp.rx_rate=rr
-				dp.tx_mcs=tm
-				dp.rx_mcs=rm
-				table.insert(dpa,dp)
+				-- convert the timestamp to seconds since epoch
+				local dtm,dtd,dty,dth,dtmin,dts=timestamp:match(datepattern)
+				timestamp_s = os.time({month=dtm,day=dtd,year=dty,hour=dth,min=dtmin,sec=dts})
+
+				insertResult(timestamp_s, signal_dbm, noise_dbm, tx_rate_mbps, rx_rate_mbps, tx_rate_mcs_index, rx_rate_mcs_index)
 			end
-			table.insert(ol,dpa)
 		end
 	end
-	return ol
+	return dpa
 end
 
 function getScanList()

--- a/files/www/cgi-bin/signal
+++ b/files/www/cgi-bin/signal
@@ -114,18 +114,18 @@ $header = <<EOF;
         toolTip: {
           contentFormatter: function (e) {
             var content = " ";
-            content += "At " + e.entries[0].dataPoint.label + "<br />";
-            if (e.entries[0].dataPoint.y[0]!="null") {
-               content += "Signal: " + e.entries[0].dataPoint.y[0] + "dBm<br/>";
+            content += "At " + e.entries[0].dataPoint.timestamp.substring(11, 19) + "<br />";
+            if (e.entries[0].dataPoint.signal_dbm) {
+               content += "Signal: " + e.entries[0].dataPoint.signal_dbm + "dBm<br/>";
             } else {
-               content += "Signal: N/A<br/>";
+               content += "Signal: 0<br/>";
             }
-            content += "Noise: " + e.entries[0].dataPoint.y[1] + "dBm<br/>";
-            content += "SNR: " + e.entries[0].dataPoint.m + "dB<br/>";
-            content += "TX Rate: " + e.entries[0].dataPoint.tx_rate + "Mbps<br/>";
-            content += "TX MCS: " + e.entries[0].dataPoint.tx_mcs + "<br/>";
-            content += "RX Rate: " + e.entries[0].dataPoint.rx_rate + "Mbps<br/>";
-            content += "RX MCS: " + e.entries[0].dataPoint.rx_mcs + "<br/>";
+            content += "Noise: " + e.entries[0].dataPoint.noise_dbm + "dBm<br/>";
+            content += "SNR: " + e.entries[0].dataPoint.snr + "dB<br/>";
+            content += "TX Rate: " + e.entries[0].dataPoint.tx_rate_mbps + "Mbps<br/>";
+            content += "TX MCS: " + e.entries[0].dataPoint.tx_rate_mcs_index + "<br/>";
+            content += "RX Rate: " + e.entries[0].dataPoint.rx_rate_mbps + "Mbps<br/>";
+            content += "RX MCS: " + e.entries[0].dataPoint.rx_rate_mcs_index + "<br/>";
             return content;
           }
         },
@@ -140,9 +140,19 @@ $header = <<EOF;
         ],
       }); // --- chart
 
+      var formatDataPoint = function(point) {
+          point.label = point.timestamp.substring(5, 10) + " " + point.timestamp.substring(11, 19);
+          point.y = [point.signal_dbm, point.noise_dbm];
+          point.snr = (point.noise_dbm * -1) - (point.signal_dbm * -1);
+          point.tx_rate_mcs_index = point.tx_rate_mcs_index ? point.tx_rate_mcs_index : "N/A";
+          point.rx_rate_mcs_index = point.rx_rate_mcs_index ? point.rx_rate_mcs_index : "N/A";
+          return point;
+      };
+
       var updateArchiveChart = function () {
         \$.getJSON("/cgi-bin/api?chart=archive&device=$parms{device}", function (result) {
-          chart.options.data[0].dataPoints = result.pages.chart.archive[0];
+          var points = result.pages.chart.archive.map(formatDataPoint);
+          chart.options.data[0].dataPoints = points;
           if(result.pages.chart.archive.constructor === Array) {
             chart.render();
           };
@@ -151,11 +161,11 @@ $header = <<EOF;
 
       var updateRealtimeChart = function () {
         \$.getJSON("/cgi-bin/api?chart=realtime&realtime=1&device=$parms{device}", function (result) {
-          dps[0].push(result.pages.chart.realtime[0][0]);
+          var point = formatDataPoint(result.pages.chart.realtime[0]);
+          dps[0].push(point);
           chart.render();
-          var snr = (result.pages.chart.realtime[0][0].y[1] * -1) - (result.pages.chart.realtime[0][0].y[0] * -1);
-          toneFreq(snr);
-          \$('#snr').html(snr);
+          toneFreq(point.snr);
+          \$('#snr').html(point.snr);
         });
       };
 


### PR DESCRIPTION
I ran into some problems while working on the chart page in [this pull request](https://github.com/aredn/aredn_ui/pull/14).  Our new charts endpoint was causing problems by returning slightly different data when using "realtime" vs. "archive".  

For example, this was the response for a **realtime** SNR data point:

```json 
[
   [
      {
         "tx_mcs":"N\/A",
         "rx_mcs":"N\/A",
         "label":"02:50:31",
         "m":74,
         "y":[
            -21,
            -95
         ],
         "rx_rate":"N\/A",
         "tx_rate":"N\/A"
      }
   ]
]
```

and this was the response for an **archive** SNR data point:

```json
[
   [
      {
         "y":[
            "null",
            -95
         ],
         "x":1555286280000,
         "rx_mcs":"-1",
         "label":"04\/15\/2019 01:58:00",
         "m":"N\/A",
         "tx_mcs":"-1",
         "rx_rate":"0",
         "tx_rate":"1"
      }
   ]
]
```

As you can see, the problems are:

1. the property names are hard to decipher at a glance
2. the returned data is nested inside 2 arrays
3. the string "null" is problematic inside the property ```y```, because sometimes that can be a number (it represents signal in dbm)
4. the "N/A" strings for ```tx_rate```, ```rx_rate```, ```tx_mcs```, and ```rx_mcs``` are problematic, because sometimes they can be numbers
5. the ```label```, which is actually a timestamp, is formatted inconsistently - one includes the date and the other does not
6. the ```m``` property can be either a number or a string
7. the ```x``` property is ```undefined```

With this change we'll get a new response for SNR data that looks like the following - and it will be the same whether it comes from the "archive" (snrlog file) or "realtime" from iwinfo:

```json
[
         {
           "signal_dbm": -28,
           "tx_rate_mbps": 1,
           "timestamp": "2019-04-15T03:59:57Z",
           "noise_dbm": -95,
           "rx_rate_mbps": 0,
           "tx_rate_mcs_index": 0,
           "rx_rate_mcs_index": 0
         }
]
```

Note that ```tx_rate_mcs_index``` and ```rx_rate_mcs_index``` can be undefined.  However, in my opinion that's better than -1 because we can make it obvious in the interface client side.  I renamed each property to make the units more understandable and also got rid of the nested array.  Margin will be calculated client side, and the time stamp will always be in ISO 8601 format in the time zone of the server.

The old signal page is updated to use this new response