### PR TITLE
Add experimental support for the GL.iNet GL-AR150

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The Mikrotik hAP AC Lite, Ubiquiti AirRouter, and AirRouter HP are pre-configure
 
 The GL.iNet GL-AR150 is pre-configured with the following VLANS:
 
-* Port labeled "WAN": untagged = AREDN LAN, vlan 1 = AREDN WAN, vlan 2 = DtDLink (device to device)
+* Port labeled "WAN": untagged = AREDN WAN
 * Port labeled "LAN": untagged = AREDN LAN, vlan 2 = DtDLink (device to device)
 
 ## Submitting Bug Reports

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Mikrotik RBLHG-5HPnD | mikrotik-rb-nor-flash-16M | 64Mb | stable
 Mikrotik RBLHG-5HPnD-XL | mikrotik-rb-nor-flash-16M | 64Mb | stable
 Mikrotik LDF-5nD | mikrotik-rb-nor-flash-16M | 64Mb | stable
 Mikrotik QRT5 RB911G-5HPnD-QRT | mikrotik-nand-large | 64Mb | stable
-GL.iNet GL-AR150 | gl-ar150 | 64Mb | EXPERIMENTAL
+GL.iNet GL-AR150 | gl-ar150 | 64Mb | stable
 
 Latest Mikrotik installation options are found at: https://www.arednmesh.org/content/installation-instructions-mikrotik-devices
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Mikrotik RBLHG-5HPnD | mikrotik-rb-nor-flash-16M | 64Mb | stable
 Mikrotik RBLHG-5HPnD-XL | mikrotik-rb-nor-flash-16M | 64Mb | stable
 Mikrotik LDF-5nD | mikrotik-rb-nor-flash-16M | 64Mb | stable
 Mikrotik QRT5 RB911G-5HPnD-QRT | mikrotik-nand-large | 64Mb | stable
+GL.iNet GL-AR150 | gl-ar150 | 64Mb | EXPERIMENTAL
 
 Latest Mikrotik installation options are found at: https://www.arednmesh.org/content/installation-instructions-mikrotik-devices
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ The Mikrotik hAP AC Lite, Ubiquiti AirRouter, and AirRouter HP are pre-configure
 * Port 5: DtDLink Port Mesh Routing -- Connect to another mesh node or 8021.q switch. Packets in/out of this port must be vlan 2 tagged, other packets are ignored.
 * Ports 2-4: LAN devices -- Packets in/out of this port are expected to be untagged. The mesh node will (default) DHCP assign an IP address to your computer, ipCam, voip phone, etc. connected to these ports.
 
+The GL.iNet GL-AR150 is pre-configured with the following VLANS:
+
+* Port labeled "WAN": untagged = AREDN LAN, vlan 1 = AREDN WAN, vlan 2 = DtDLink (device to device)
+* Port labeled "LAN": untagged = AREDN LAN, vlan 2 = DtDLink (device to device)
+
 ## Submitting Bug Reports
 
 Please submit all issues to http://github.com/aredn/aredn_ar71xx/issues

--- a/configs/ar71xx-generic.config
+++ b/configs/ar71xx-generic.config
@@ -20,6 +20,7 @@ CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-rocket-m-ti=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-rocket-m-xw=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-rocket-m=y
 CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_ubnt-lbe-m5=y
+CONFIG_TARGET_DEVICE_ar71xx_generic_DEVICE_gl-ar150=y
 CONFIG_HAS_SUBTARGETS=y
 CONFIG_HAS_DEVICES=y
 CONFIG_TARGET_BOARD="ar71xx"

--- a/files/usr/local/bin/linkled
+++ b/files/usr/local/bin/linkled
@@ -24,6 +24,9 @@ case "$BOARD_TYPE" in
 	airrouter)
 		LINK1LED=$(readlink -f '/sys/class/leds/ubnt:green:globe')
 		;;
+	gl-ar150)
+		LINK1LED=$(readlink -f '/sys/class/leds/gl-ar150:orange:wlan')
+		;;
 	rb-912uag-5hpnd|rb-911g-5hpnd)
 		LINK1LED=$(readlink -f '/sys/class/leds/rb:green:led1')
                 ;;

--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -984,7 +984,7 @@ sub hardware_info
   %model = (
     'GL.iNet GL-AR150' => {
       'name'            => 'GL.iNet GL-AR150',
-      'comment'         => 'EXPERIMENTAL',
+      'comment'         => '',
       'supported'       => '1',
       'maxpower'        => '18',
       'pwroffset'       => '0',

--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -982,6 +982,15 @@ sub hardware_boardid
 sub hardware_info
 {
   %model = (
+    'GL.iNet GL-AR150' => {
+      'name'            => 'GL.iNet GL-AR150',
+      'comment'         => 'EXPERIMENTAL',
+      'supported'       => '1',
+      'maxpower'        => '20',
+      'pwroffset'       => '0',
+      'usechains'       => 0,
+      'rfband'          => '2400',
+    },
     'TP-Link CPE210 v1.0' => {
       'name'            => 'TP-Link CPE210 v1.0',
       'comment'         => '',

--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -986,7 +986,7 @@ sub hardware_info
       'name'            => 'GL.iNet GL-AR150',
       'comment'         => 'EXPERIMENTAL',
       'supported'       => '1',
-      'maxpower'        => '20',
+      'maxpower'        => '18',
       'pwroffset'       => '0',
       'usechains'       => 0,
       'rfband'          => '2400',

--- a/patches/001-add_support_for_GL-iNet_GL-AR150.patch
+++ b/patches/001-add_support_for_GL-iNet_GL-AR150.patch
@@ -1,0 +1,15 @@
+Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/01_leds
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ openwrt/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -422,8 +422,8 @@ gl-mifi)
+ 	;;
+ gl-ar150)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:orange:wlan" "phy0tpt"
+-	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+-	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth1"
++	ucidef_set_led_netdev "wan" "WAN" "$board:green:lan" "eth0"
++	ucidef_set_led_netdev "lan" "LAN" "$board:green:wan" "eth1"
+ 	;;
+ gl-ar300)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:wlan" "phy0tpt"

--- a/patches/708-define-aredn-networks.patch
+++ b/patches/708-define-aredn-networks.patch
@@ -64,7 +64,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  	pqi-air-pen|\
  	rb-411|\
  	rb-411u|\
-@@ -156,7 +159,9 @@ ar71xx_setup_interfaces()
+@@ -157,7 +160,9 @@ ar71xx_setup_interfaces()
  	wifi-pineapple-nano|\
  	wndap360|\
  	wp543)
@@ -75,7 +75,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  		;;
  	a40|\
  	a60|\
-@@ -175,7 +180,6 @@ ar71xx_setup_interfaces()
+@@ -176,7 +181,6 @@ ar71xx_setup_interfaces()
  	pb42|\
  	pb44|\
  	rb-951ui-2hnd|\
@@ -83,14 +83,12 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  	routerstation|\
  	tl-wr710n|\
  	tl-wr720n-v3|\
-@@ -183,15 +187,24 @@ ar71xx_setup_interfaces()
- 	tl-wr810n-v2|\
+@@ -185,14 +189,23 @@ ar71xx_setup_interfaces()
  	wpe72|\
  	wrtnode2q)
--		ucidef_set_interfaces_lan_wan "eth1" "eth0"
-+		ucidef_set_interfaces_lan_wan "eth0" "eth0.1"
+ 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 +		ucidef_set_interface_raw "wifi" "wlan0" "static"
-+		ucidef_set_interface_raw "dtdlink" "eth0.2" "static"
++		ucidef_set_interface_raw "dtdlink" "eth1.2" "static"
  		;;
  	rb-750-r2|\
  	rb-750p-pbr2|\
@@ -111,7 +109,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  		;;
  	all0258n|\
  	all0315n|\
-@@ -201,7 +214,9 @@ ar71xx_setup_interfaces()
+@@ -202,7 +215,9 @@ ar71xx_setup_interfaces()
  	ja76pf2|\
  	rocket-m-ti|\
  	ubnt-unifi-outdoor)
@@ -122,7 +120,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  		;;
  	wzr-hp-g300nh2)
  		ucidef_add_switch "switch0" \
-@@ -216,8 +231,9 @@ ar71xx_setup_interfaces()
+@@ -217,8 +232,9 @@ ar71xx_setup_interfaces()
  	rb-962uigs-5hact2hnt|\
  	wlr8100|\
  	wzr-hp-g450h)
@@ -133,7 +131,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  		;;
  	ap135-020|\
  	ap136-020|\
-@@ -299,11 +315,13 @@ ar71xx_setup_interfaces()
+@@ -300,11 +316,13 @@ ar71xx_setup_interfaces()
  	cpe510|\
  	wbs210|\
  	wbs510)
@@ -148,7 +146,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  		ucidef_add_switch "switch0" \
  			"0@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
  		;;
-@@ -455,10 +473,6 @@ ar71xx_setup_interfaces()
+@@ -456,10 +474,6 @@ ar71xx_setup_interfaces()
  		ucidef_add_switch "switch0" \
  			"0@eth0" "1:lan" "5:wan" "6@eth1"
  		;;
@@ -159,7 +157,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  	onion-omega)
  		ucidef_set_interface_lan "wlan0"
  		;;
-@@ -468,9 +482,10 @@ ar71xx_setup_interfaces()
+@@ -469,9 +483,10 @@ ar71xx_setup_interfaces()
  			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5@eth1"
  		;;
  	routerstation-pro)
@@ -172,7 +170,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/board.d/02_network
  		;;
  	rb-493g)
  		ucidef_set_interfaces_lan_wan "eth0.1 eth1.1" "eth1.2"
-@@ -571,8 +586,16 @@ ar71xx_setup_interfaces()
+@@ -572,8 +587,16 @@ ar71xx_setup_interfaces()
  		ucidef_add_switch "switch0" \
  			"0@eth0" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4" "5:wan"
  		;;

--- a/patches/series
+++ b/patches/series
@@ -1,3 +1,4 @@
+001-add_support_for_GL-iNet_GL-AR150.patch
 001-add_support_for_TP-Link_CPE210_v3.patch
 001-add_support_for_TP-Link_CPE510_v2.patch
 001-add_support_for_TP-Link_CPE610_v1.patch


### PR DESCRIPTION
I was surprised at how easy it was to build AREDN firmware for the GL.iNet GL-AR150
These devices are available from the usual sources for $20 - $30 USD or so - an economy mesh node.
https://openwrt.org/toh/gl.inet/gl-ar150

Mesh networking and tunnelling have been confirmed working.
This device has also been confirmed capable of meshing on channel -1, but /etc/config/wireless has to be manually edited to select this channel because the AREDN web UI does not allow it to be selected (unlike the UBNT Rocket M2 etc).


Following is from: http://zl2wrw-65-83-239.local.mesh:8080/cgi-bin/sysinfo

 node: ZL2WRW-65-83-239
model: Unknown Hardware 

!!!! UNSUPPORTED DEVICE !!!!
boardid: GL.iNet GL-AR150
Device has not been tested. Please file a ticket with your experiences.

br-lan E4:95:6E:42:53:EF
eth0   E4:95:6E:42:53:EF
eth0.1 E4:95:6E:42:53:EF
eth0.2 E4:95:6E:42:53:EF
eth1   E4:95:6E:41:53:EF
tunl0  00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
wlan0  E4:95:6E:41:53:EF
wlan0-1 E6-95-6E-41-53-EF-00-00-00-00-00-00-00-00-00-00

/proc/cpuinfo
system type		: Atheros AR9330 rev 1
machine			: GL.iNet GL-AR150
processor		: 0
cpu model		: MIPS 24Kc V7.4
BogoMIPS		: 265.42
wait instruction	: yes
microsecond timers	: yes
tlb_entries		: 16
extra interrupt vector	: yes
hardware watchpoint	: yes, count: 4, address/irw mask: [0x0ffc, 0x0ffc, 0x0ffb, 0x0ffb]
isa			: mips1 mips2 mips32r1 mips32r2
ASEs implemented	: mips16
shadow register sets	: 1
kscratch registers	: 0
package			: 0
core			: 0
VCED exceptions		: not available
VCEI exceptions		: not available


nvram
hsmmmesh.settings=settings
hsmmmesh.settings.wifimac='e4:95:6e:41:53:ef'
hsmmmesh.settings.mac2='65.83.239'
hsmmmesh.settings.dtdmac='65.83.239'
hsmmmesh.settings.config='mesh'
hsmmmesh.settings.node='ZL2WRW-65-83-239'