### PR TITLE
bugfix: fix call to getFrequency() to getFreq() in api

### DIFF
--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -70,7 +70,7 @@ function getStatusMeshRF()
 	info['channel']=aredn_info.getChannel(info['device'])
 	info['chanbw']=aredn_info.getChannelBW(info['device'])
 	info['band']=aredn_info.getBand(info['device'])
-	info['frequency']=aredn_info.getFrequency(info['device'])
+	info['frequency']=aredn_info.getFreq(info['device'])
 	return info
 end
 


### PR DESCRIPTION
getFrequency() becomes getFreq()

I found this while I was getting the new UI test setup.