### PR TITLE
aredn: new LDF5 model number

### DIFF
--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -1165,6 +1165,15 @@ sub hardware_info
       'usechains'       => 1,
       'rfband'          => '5800ubntus',
     },
+    'MikroTik RouterBOARD RBLDF-5nD' => {
+      'name'            => 'MikroTik RouterBOARD RBLDF-5nD',
+      'comment'         => '',
+      'supported'       => '1',
+      'maxpower'        => '25',
+      'pwroffset'       => '0',
+      'usechains'       => 1,
+      'rfband'          => '5800ubntus',
+    },
     'MikroTik RouterBOARD LHG 5nD' => {
       'name'            => 'MikroTik RouterBOARD LHG 5nD',
       'comment'         => '',

--- a/patches/004-add-ldf-5nd.patch
+++ b/patches/004-add-ldf-5nd.patch
@@ -40,11 +40,14 @@ Index: openwrt/target/linux/ar71xx/base-files/lib/ar71xx.sh
 ===================================================================
 --- openwrt.orig/target/linux/ar71xx/base-files/lib/ar71xx.sh
 +++ openwrt/target/linux/ar71xx/base-files/lib/ar71xx.sh
-@@ -1121,6 +1121,9 @@ ar71xx_board_detect() {
+@@ -1121,6 +1121,12 @@ ar71xx_board_detect() {
  	*"RouterBOARD LHG 5HPnD-XL")
  		name="rb-lhg-5hpnd-xl"
  		;;
 +	*"RouterBOARD LDF-5nD")
++		name="rb-ldf-5nd"
++		;;
++	*"RouterBOARD RBLDF-5nD")
 +		name="rb-ldf-5nd"
 +		;;
  	*"RouterBOARD mAP 2nD")


### PR DESCRIPTION
Mikrotik change from "MikroTik RouterBOARD LDF-5nD"
to "MikroTik RouterBOARD RBLDF-5nD"