### PR TITLE
api: add first_boot field to indicate if this node has been configured

### DIFF
--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -49,6 +49,14 @@ require("iwinfo")
 -------------------------------------
 local model = {}
 
+
+-------------------------------------
+-- Get FIRST_BOOT status
+-------------------------------------
+function model.getFirstBoot()
+	return (model.getNodeName()=="NOCALL")
+end
+
 -------------------------------------
 -- Returns WAN Address
 -------------------------------------

--- a/files/www/cgi-bin/api
+++ b/files/www/cgi-bin/api
@@ -60,6 +60,7 @@ function getSysinfo()
 	--
 	info['uptime']=aredn_info.getUptime()
 	info['loads']=aredn_info.getLoads()
+	info['first_boot']=aredn_info.getFirstBoot()
 	return info
 end
 


### PR DESCRIPTION
on first_boot, a call to /api?status=sysinfo will now return:

```
{
   "pages": {
     "status": {
       "sysinfo": {
         "first_boot": true,
         "uptime": 3112,
         "time": "13:12:43 UTC",
         "model": "GL.iNet GL-USB150 ",
         "date": "Wed Jan 30 2019",
         "loads": [
           0.029999999999999999,
           0.029999999999999999,
           0.029999999999999999
         ],
         "node": "NOCALL",
         "firmware_version": "902-9566393"
       }
     }
   }
 }
```