### PR TITLE
feature: add "MESH" led for GL USB150

### DIFF
--- a/files/usr/local/bin/linkled
+++ b/files/usr/local/bin/linkled
@@ -27,6 +27,9 @@ case "$BOARD_TYPE" in
 	gl-ar150)
 		LINK1LED=$(readlink -f '/sys/class/leds/gl-ar150:orange:wlan')
 		;;
+	gl-usb150)
+		LINK1LED=$(readlink -f '/sys/class/leds/gl-usb150:green:wlan')
+		;;
 	rb-912uag-5hpnd|rb-911g-5hpnd)
 		LINK1LED=$(readlink -f '/sys/class/leds/rb:green:led1')
                 ;;


### PR DESCRIPTION
enabled the green LED towards the "wifi" end of the device to be the "MESH" active indicator.