### PR TITLE
bugfix: Mesh status missing owning host of service advertisement

### DIFF
--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -435,6 +435,7 @@ foreach $ip (keys %hosts)
     $tactical = $hosts{$ip}{tactical} ? " / " . $hosts{$ip}{tactical} : "";
     $etx = sprintf "%.2f", $hosts{$ip}{etx};
     next if ($etx > 50 );
+    next if ($etx == 0 );
 
     $rows{$host}  = sprintf "<tr><td valign=top><nobr><a href='http://%s:8080/'>%s</a>", $host, $host . $tactical;
 


### PR DESCRIPTION
Mesh status will show service entries of a remote mesh
node at the top with 0 ETX value.  The owning mesh hostname
displays blank across the mesh network.

The root cause is OLSR not propagating the node's hostname due
to the admin assigning  a conflicting/duplicate hostname.  These
services will no longer show in mesh status.