### PR TITLE
aredn: check less frequently to update Mesh link LED

### DIFF
--- a/files/usr/local/bin/linkled
+++ b/files/usr/local/bin/linkled
@@ -67,7 +67,7 @@ link_state() {
 		reset_led
 
 		while true; do
-			sleep 5;
+			sleep 11;
 			if echo /nei | nc 127.0.0.1 2006 2>/dev/null | grep -q YES; then
 				echo 1 > "$LINK1LED/brightness"
 			else


### PR DESCRIPTION
OLSR has rare symptoms of live lock and stops
updating routing and host information.  Suspect cause is
single threaded implementation with plugins continually
called from mutiple sources.  Prior fixes to ensure
read/write calls are properly written may not have
fully resolved the causes.  This change will reduce calls
to retrieve olsr data.