### PR TITLE
bugfix: Fix instance of sysupgrade failing

### DIFF
--- a/patches/007-fix-sysupgrade-fail.patch
+++ b/patches/007-fix-sysupgrade-fail.patch
@@ -1,0 +1,30 @@
+From: Jeff Kletsky <git-commits@allycomm.com>
+
+Wifi can, in certain situations, cause sysupgrade to fail silently
+with a 256 return value as all processes can't be killed.
+One of these situations is mesh with batman-adv active.
+
+Added `wifi down` just prior to the killall sequence in stage2
+
+Run-tested-on: Linksys EA8300
+
+Signed-off-by: Jeff Kletsky <git-commits@allycomm.com>
+---
+package/base-files/files/lib/upgrade/stage2 | 4 ++++
+1 file changed, 4 insertions(+)
+
+Index: openwrt/package/base-files/files/lib/upgrade/stage2
+===================================================================
+--- openwrt.orig/package/base-files/files/lib/upgrade/stage2
++++ openwrt/package/base-files/files/lib/upgrade/stage2
+@@ -122,6 +122,10 @@ kill_remaining() { # [ <signal> [ <loop>
+ 	echo
+ }
+ 
++if [-x "$(which wifi)"]; then
++	wifi down
++	sleep 1
++fi
+ 
+ killall -9 telnetd
+ killall -9 dropbear

--- a/patches/series
+++ b/patches/series
@@ -11,6 +11,7 @@
 004-add-ldf-5nd.patch
 005-add-haplite-new-model.patch
 006-add-lhg-5hpnd.patch
+007-fix-sysupgrade-fail.patch
 700-cpe-diags.patch
 701-extended-spectrum.patch
 702-enable-country-hx.patch


### PR DESCRIPTION
It was discovered that sysupgrade would exit with an
error when some processes could not be killed.  The
wifi interface is brought down to avoid this condition
prior to doing the sysupgrade