### PR TITLE
bugfix: wan interface fails to function on UBNT NS XM devices

### DIFF
--- a/files/usr/local/bin/wifi-setup
+++ b/files/usr/local/bin/wifi-setup
@@ -57,7 +57,7 @@ meshphy="phy${meshif#wlan}"
 
 wan_intf=`cat /etc/board.json|jsonfilter -e '@.network.wan.ifname'`
 uci -c ${dropdir} -q batch > /dev/null <<-EOF
-set network.wan.ifname=$wan_intf
+set network.wan.ifname="$wan_intf"
 EOF
 uci -c ${dropdir} -q commit network
 


### PR DESCRIPTION
The WAN network fails to be configured correctly on
UBNT NS XM devices.