### PR TITLE
aredn: switch from active to passive wifi scan

### DIFF
--- a/files/etc/httpd.conf
+++ b/files/etc/httpd.conf
@@ -4,6 +4,5 @@
 /cgi-bin/vpn:root:$p$root
 /cgi-bin/vpnc:root:$p$root
 /cgi-bin/supporttool:root:$p$root
-/cgi-bin/scan:root:$p$root
 /cgi-bin/advancedconfig:root:$p$root
 /cgi-bin/apiprotected:root:$p$root

--- a/files/usr/local/bin/wscan
+++ b/files/usr/local/bin/wscan
@@ -168,7 +168,7 @@ die "bad interface" if not defined $iface;
 
 if($raw)
 {
-  system("iw dev $iface scan");
+  system("iw dev $iface scan passive");
   system("iw dev $iface station dump");
   exit;
 }
@@ -179,7 +179,7 @@ while(1)
   $line   =~ /['"](.*-(5|10|20)-v[3456])/;
   $myssid = $1;
 
-  open(FILE, "iw dev $iface scan 2>&1 |") or die "iw scan failed";
+  open(FILE, "iw dev $iface scan passive 2>&1 |") or die "iw scan failed";
   $mac = "";
   $host = "N/A";
   $lastseen = 0;


### PR DESCRIPTION
Password protection is no longer necessary with
a passive scan.  results are same or very similiar,
both options do not always show all devices.