### PR TITLE
cleanup: remove the `meshmap=1` option from sysinfo.json.

### DIFF
--- a/files/www/cgi-bin/sysinfo.json
+++ b/files/www/cgi-bin/sysinfo.json
@@ -167,12 +167,6 @@ if string.find(nixio.getenv("QUERY_STRING"):lower(),"link_info=1") then
 	info['link_info']=aredn_olsr.getCurrentNeighbors(true)
 end
 
--- MESHMAP INFO
-if string.find(nixio.getenv("QUERY_STRING"):lower(),"meshmap=1") then
-	info['services_local']=aredn_info.local_services()
-	info['link_info']=aredn_olsr.getCurrentNeighbors(true)
-end
-
 -- Output the HTTP header for JSON
 json_header()
 


### PR DESCRIPTION
It is no longer needed and never actually was.
You learn something new every day. :)

Every bit saved is a bit earned for something else.