### PR TITLE
fix: fix status led for the wbs510-v2

### DIFF
--- a/patches/700-cpe-diags.patch
+++ b/patches/700-cpe-diags.patch
@@ -2,7 +2,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/diag.sh
 ===================================================================
 --- openwrt.orig/target/linux/ar71xx/base-files/etc/diag.sh
 +++ openwrt/target/linux/ar71xx/base-files/etc/diag.sh
-@@ -163,9 +163,19 @@ get_status_led() {
+@@ -163,9 +163,20 @@ get_status_led() {
  	cf-e385ac)
  		status_led="$board:blue:wlan2g"
  		;;
@@ -13,6 +13,7 @@ Index: openwrt/target/linux/ar71xx/base-files/etc/diag.sh
 +	cpe510-v2|\
 +	cpe510-v3|\
 +	cpe210|\
++	wbs510-v2|\
  	cpe510)
  		status_led="tp-link:green:link4"
  		;;


### PR DESCRIPTION
fix status led for the wbs510-v2