### PR TITLE
enhancement: add throughput info for each link to sysinfo.json

### DIFF
--- a/files/usr/lib/lua/aredn/info.lua
+++ b/files/usr/lib/lua/aredn/info.lua
@@ -44,6 +44,7 @@ require("nixio")
 require("ubus")
 require("iwinfo")
 
+os.capture=capture
 -------------------------------------
 -- Public API is attached to table
 -------------------------------------
@@ -487,4 +488,23 @@ function model.getLocalHosts()
 	return hosts
 end
 
+---------------------------------
+-- Returns Throughput of an interface
+-- checks /proc/net/dev twice, waiting 1 second between
+-- returns a string, "rx tx", in Bytes for the 1 second interval
+---------------------------------
+function getThroughput(inf)
+    rxtx0={}
+    rxtx1={}
+    match=string.chomp(os.capture("grep "..inf.." /proc/net/dev"))
+    for substr in string.gmatch(match, "%S+") do
+      table.insert(rxtx0, substr)
+    end
+    sleep(1)
+    match=string.chomp(os.capture("grep "..inf.." /proc/net/dev"))
+    for substr in string.gmatch(match, "%S+") do
+      table.insert(rxtx1, substr)
+    end
+    return rxtx1[2]-rxtx0[2].." "..rxtx1[10]-rxtx0[10]
+end
 return model

--- a/files/usr/lib/lua/aredn/olsr.lua
+++ b/files/usr/lib/lua/aredn/olsr.lua
@@ -66,6 +66,7 @@ function model.getCurrentNeighbors(RFinfo)
     local remip=v['remoteIP']
     local remhost=nslookup(remip)
     info[remip]={}
+    info[remip]['throughput']=getThroughput(v['olsrInterface'])
     info[remip]['olsrInterface']=v['olsrInterface']
     info[remip]['linkType']= model.getOLSRInterfaceType(v['olsrInterface'])    -- RF or DTD or TUN
     info[remip]['linkQuality']=v['linkQuality']


### PR DESCRIPTION
when `sysinfo.json` is called with `link_info=1` throughput info will be added for each link.
This runs grep against `/proc/net/dev` for each _linked_ interface over a 1 second interval.
it does slow down the response time of sysinfo.json, depending on how many linked interfaces there are.
I have many active tunnels and have not had any issues.

output is a string "RX TX" in **bytes** for that 1 second interval.

This could be useful for local graphing or other things.
I have some ideas to use it for the meshmap in the future.