### PR TITLE
bugfix: aredn: Port Forward not working over dtdlink in LAN NAT mode

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -380,14 +380,17 @@ foreach(`cat $portfile`)
   if($intf eq "both")
   {
     print FILE "\nconfig redirect\n\toption src              wifi\n\t$match\toption src_dip          $cfg{wifi_ip}\n\t$host\n";
+    print FILE "\nconfig redirect\n\toption src              dtdlink\n\t$match\toption src_dip          $cfg{wifi_ip}\n\t$host\n";
     print FILE "config redirect\n\toption src              wan\n\t$match\t$host\n";
   }
   elsif($intf eq "wifi")
   {
+    print FILE "\nconfig redirect\n\toption src              dtdlink\n\t$match\toption src_dip          $cfg{wifi_ip}\n\t$host\n";
     print FILE "config redirect\n\toption src              wifi\n\t$match\toption src_dip          $cfg{wifi_ip}\n\t$host\n";
   }
   elsif($intf eq "wan")
   {
+    print FILE "\nconfig redirect\n\toption src              dtdlink\n\t$match\toption          src_dip $cfg{wifi_ip}\n\t$host\n";
     print FILE "config redirect\n\toption src              wan\n\t$match\t$host\n";
   }
   else


### PR DESCRIPTION
fixes #449
tested by: Timm Schunck <dl4fly@darc.de>