### PR TITLE
enhancement: Download paths

### DIFF
--- a/files/etc/init.d/local
+++ b/files/etc/init.d/local
@@ -84,7 +84,9 @@ boot() {
     # get the URLs from distfeeds.conf and set the initial UCI values if not present
     if [ -z $ucirepo ]; then
       uci set aredn.@downloads[0].pkgs_$1=$distrepo
-      uci -q commit aredn
+      uci commit aredn
+      uci -c /etc/config.mesh set aredn.@downloads[0].pkgs_$1=$distrepo
+      uci -c /etc/config.mesh commit aredn
     # check values in distfeeds.conf against UCI settings
     # and change distfeeds.conf if needed (upgrades?)
     ## commented for now, may need it later

--- a/files/etc/init.d/local
+++ b/files/etc/init.d/local
@@ -74,4 +74,23 @@ boot() {
     usbvalue=$duval
   fi
   /usr/local/bin/usb_passthrough "${usbvalue}"
+
+  # package repositorys
+  local repos="core base arednpackages packages luci routing telephony"
+  set -- $repos
+  while [ -n "$1" ]; do
+    local ucirepo=$(uci -q get aredn.@downloads[0].pkgs_$1)
+    local distrepo=$(grep aredn_$1 /etc/opkg/distfeeds.conf | cut -d' ' -f3)
+    # get the URLs from distfeeds.conf and set the initial UCI values if not present
+    if [ -z $ucirepo ]; then
+      uci set aredn.@downloads[0].pkgs_$1=$distrepo
+      uci -q commit aredn
+    # check values in distfeeds.conf against UCI settings
+    # and change distfeeds.conf if needed (upgrades?)
+    ## commented for now, may need it later
+    #elif [ $ucirepo != $distrepo ]; then
+    #  sed -i "s|$distrepo|$ucirepo|g" /etc/opkg/distfeeds.conf
+    fi
+    shift
+  done
 }

--- a/files/www/cgi-bin/admin
+++ b/files/www/cgi-bin/admin
@@ -168,7 +168,7 @@ if(${hardwaretype} eq "nanostation-m")
 # refresh fw
 if($parms{button_refresh_fw})
 {
-    if(get_default_gw() ne "none")
+    if((get_default_gw() ne "none") || ($uciserverpath =~ ".local.mesh"))
     {
 	push @fw_output, "Downloading firmware list from $uciserverpath...\n";
 	unlink "/tmp/web/firmware.list";
@@ -184,7 +184,7 @@ if($parms{button_refresh_fw})
     }
     else
     {
-	push @fw_output, "Error: no route to the Internet\n";
+	push @fw_output, "Error: no route to the Host\n";
 	unlink "/tmp/web/firmware.list";
     }
 }
@@ -233,7 +233,7 @@ if($parms{button_ul_fw} and -f "/tmp/web/upload/file")
 # download fw
 if($parms{button_dl_fw} and $parms{dl_fw} ne "default")
 {
-    if(get_default_gw() ne "none")
+    if((get_default_gw() ne "none") || ($uciserverpath =~ ".local.mesh"))
     {
 	unlink "$tmpdir/firmware";
 	system("/usr/local/bin/uploadctlservices","upgrade");
@@ -298,7 +298,7 @@ if($parms{button_dl_fw} and $parms{dl_fw} ne "default")
     }
     else
     {
-	push @fw_output, "Error: no route to the Internet\n";
+	push @fw_output, "Error: no route to the Host\n";
 	unlink "/tmp/web/firmware.list";
     }
 }
@@ -483,9 +483,10 @@ if($parms{button_ul_pkg} and -f "/tmp/web/upload/file")
 } 
 
 # download package
+$meshpkgs = system('grep -q ".local.mesh" /etc/opkg/distfeeds.conf');
 if($parms{button_dl_pkg} and $parms{dl_pkg} ne "default")
 {
-    if(get_default_gw() ne "none")
+    if((get_default_gw() ne "none") || (!$meshpkgs))
     {
 	system("/usr/local/bin/uploadctlservices","opkginstall");
 	push @pkg_output, `opkg -force-overwrite install $parms{dl_pkg} 2>&1`;
@@ -493,21 +494,21 @@ if($parms{button_dl_pkg} and $parms{dl_pkg} ne "default")
     }
     else
     {
-	push @pkg_output, "Error: no route to the Internet\n";
+	push @pkg_output, "Error: no route to the Host\n";
     }
 } 
 
 # refresh package list
 if($parms{button_refresh_pkg})
 {
-    if(get_default_gw() ne "none")
+    if((get_default_gw() ne "none") || (!$meshpkgs))
     {
 	@pkg_output = `opkg update 2>&1`;
 	system "opkg list | grep -v '^ ' | cut -f1,3 -d' ' | gzip -c > /etc/opkg.list.gz";
     }
     else
     {
-	push @pkg_output, "Error: no route to the Internet\n";
+	push @pkg_output, "Error: no route to the Host\n";
     }
 } 
 

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -62,12 +62,65 @@ push @setting, {
   desc => "Specifies the URL of the leaflet.js file", 
   default => "http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js" 
 };
+# FIRMWARE DOWNLOAD
 push @setting, {
   key => "aredn.\@downloads[0].firmwarepath", 
   type => "string", 
   desc => "Specifies the URL of the location from which firmware files will be downloaded.", 
-  default => "http://downloads.arednmesh.org/firmware/ubnt"
+  default => firmwareDownload()
 };
+
+#PACKAGE DOWNLOAD
+push @setting, {
+  key => "aredn.\@downloads[0].pkgs_core",
+  type => "string",
+  desc => "Specifies the URL for the 'core' packages: kernel modules and the like",
+  default => defaultPackageRepos('aredn_core'),
+  postcallback => writePackageRepo('core')
+};
+push @setting, {
+  key => "aredn.\@downloads[0].pkgs_base",
+  type => "string",
+  desc => "Specifies the URL for the 'base' packages: libraries, shells, etc.",
+  default => defaultPackageRepos('base'),
+  postcallback => writePackageRepo('base')
+};
+push @setting, {
+  key => "aredn.\@downloads[0].pkgs_arednpackages",
+  type => "string",
+  desc => "Specifies the URL for the 'arednpackages' packages: vtun, etc.",
+  default => defaultPackageRepos('arednpackages'),
+  postcallback => writePackageRepo('arednpackages')
+};
+push @setting, {
+  key => "aredn.\@downloads[0].pkgs_luci",
+  type => "string",
+  desc => "Specifies the URL for the 'luci' packages: luci and things needed for luci.",
+  default => defaultPackageRepos('luci'),
+  postcallback => writePackageRepo('luci')
+};
+push @setting, {
+  key => "aredn.\@downloads[0].pkgs_packages",
+  type => "string",
+  desc => "Specifies the URL for the 'packages' packages: everything not included in the other dirs.",
+  default => defaultPackageRepos('packages'),
+  postcallback => writePackageRepo('packages')
+};
+push @setting, {
+  key => "aredn.\@downloads[0].pkgs_routing",
+  type => "string",
+  desc => "Specifies the URL for the 'routing' packages: olsr, etc.",
+  default => defaultPackageRepos('routing'),
+  postcallback => writePackageRepo('routing')
+};
+push @setting, {
+  key => "aredn.\@downloads[0].pkgs_telephony",
+  type => "string",
+  desc => "Specifies the URL for the 'telephony' packages.",
+  default => defaultPackageRepos('telephony'),
+  postcallback => writePackageRepo('telephony')
+};
+
 push @setting, {
   key => "aredn.\@poe[0].passthrough", 
   type => "boolean", 
@@ -92,6 +145,20 @@ push @setting, {
 };
 
 # ----------------------------------------
+
+# ----- package repo functions -----
+sub getPackageRepo {
+  my $repo = @_[0];
+  my $file = '/etc/opkg/distfeeds.conf';
+  #chomp $repo;
+  open my $fh, '<', $file or die "Could not open $file!";
+  while(my $row = <$fh>) {
+    if($row =~ /\b$repo\b/) {
+      my @url = split / /, $row;
+      return chomp @url[2];
+    }
+  }
+}
 
 # ----- CONDITIONS ----------
 sub hasPOE()
@@ -129,6 +196,15 @@ sub olsr_restart()
   return $rc;
 }
 
+sub writePackageRepo {
+  my $repo = @_[0];
+  my $uciurl = `uci get aredn.\@downloads[0].pkgs_$repo`;
+  chomp($uciurl);
+  my $file = '/etc/opkg/distfeeds.conf';
+  my $disturl = `grep aredn_$repo /etc/opkg/distfeeds.conf | cut -d' ' -f3`;
+  chomp($disturl);
+  `sed -i "s|$disturl|$uciurl|g" $file`;
+}
 # ----- CALLBACKS ----------
 
 read_postdata({acceptfile => false});

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -67,7 +67,7 @@ push @setting, {
   key => "aredn.\@downloads[0].firmwarepath", 
   type => "string", 
   desc => "Specifies the URL of the location from which firmware files will be downloaded.", 
-  default => "http://downloads.arednmesh.org/firmware/ubnt"
+  default => "http://downloads.arednmesh.org/firmware"
 };
 
 #PACKAGE DOWNLOAD

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -67,7 +67,7 @@ push @setting, {
   key => "aredn.\@downloads[0].firmwarepath", 
   type => "string", 
   desc => "Specifies the URL of the location from which firmware files will be downloaded.", 
-  default => "http://downloads.arednmesh.org/firmware"
+  default => "http://downloads.arednmesh.org/firmware/ubnt"
 };
 
 #PACKAGE DOWNLOAD

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -76,49 +76,49 @@ push @setting, {
   type => "string",
   desc => "Specifies the URL for the 'core' packages: kernel modules and the like",
   default => defaultPackageRepos('aredn_core'),
-  postcallback => writePackageRepo('core')
+  postcallback => "writePackageRepo('core')"
 };
 push @setting, {
   key => "aredn.\@downloads[0].pkgs_base",
   type => "string",
   desc => "Specifies the URL for the 'base' packages: libraries, shells, etc.",
   default => defaultPackageRepos('base'),
-  postcallback => writePackageRepo('base')
+  postcallback => "writePackageRepo('base')"
 };
 push @setting, {
   key => "aredn.\@downloads[0].pkgs_arednpackages",
   type => "string",
   desc => "Specifies the URL for the 'arednpackages' packages: vtun, etc.",
   default => defaultPackageRepos('arednpackages'),
-  postcallback => writePackageRepo('arednpackages')
+  postcallback => "writePackageRepo('arednpackages')"
 };
 push @setting, {
   key => "aredn.\@downloads[0].pkgs_luci",
   type => "string",
   desc => "Specifies the URL for the 'luci' packages: luci and things needed for luci.",
   default => defaultPackageRepos('luci'),
-  postcallback => writePackageRepo('luci')
+  postcallback => "writePackageRepo('luci')"
 };
 push @setting, {
   key => "aredn.\@downloads[0].pkgs_packages",
   type => "string",
   desc => "Specifies the URL for the 'packages' packages: everything not included in the other dirs.",
   default => defaultPackageRepos('packages'),
-  postcallback => writePackageRepo('packages')
+  postcallback => "writePackageRepo('packages')"
 };
 push @setting, {
   key => "aredn.\@downloads[0].pkgs_routing",
   type => "string",
   desc => "Specifies the URL for the 'routing' packages: olsr, etc.",
   default => defaultPackageRepos('routing'),
-  postcallback => writePackageRepo('routing')
+  postcallback => "writePackageRepo('routing')"
 };
 push @setting, {
   key => "aredn.\@downloads[0].pkgs_telephony",
   type => "string",
   desc => "Specifies the URL for the 'telephony' packages.",
   default => defaultPackageRepos('telephony'),
-  postcallback => writePackageRepo('telephony')
+  postcallback => "writePackageRepo('telephony')"
 };
 
 push @setting, {

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -146,20 +146,6 @@ push @setting, {
 
 # ----------------------------------------
 
-# ----- package repo functions -----
-sub getPackageRepo {
-  my $repo = @_[0];
-  my $file = '/etc/opkg/distfeeds.conf';
-  #chomp $repo;
-  open my $fh, '<', $file or die "Could not open $file!";
-  while(my $row = <$fh>) {
-    if($row =~ /\b$repo\b/) {
-      my @url = split / /, $row;
-      return chomp @url[2];
-    }
-  }
-}
-
 # ----- CONDITIONS ----------
 sub hasPOE()
 {
@@ -203,7 +189,8 @@ sub writePackageRepo {
   my $file = '/etc/opkg/distfeeds.conf';
   my $disturl = `grep aredn_$repo /etc/opkg/distfeeds.conf | cut -d' ' -f3`;
   chomp($disturl);
-  `sed -i "s|$disturl|$uciurl|g" $file`;
+  #`sed -i "s|$disturl|$uciurl|g" $file`;
+  system("sed -i 's|$disturl|$uciurl|g' $file");
 }
 # ----- CALLBACKS ----------
 

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -67,7 +67,7 @@ push @setting, {
   key => "aredn.\@downloads[0].firmwarepath", 
   type => "string", 
   desc => "Specifies the URL of the location from which firmware files will be downloaded.", 
-  default => firmwareDownload()
+  default => "http://downloads.arednmesh.org/firmware/ubnt"
 };
 
 #PACKAGE DOWNLOAD

--- a/files/www/cgi-bin/advancedconfig
+++ b/files/www/cgi-bin/advancedconfig
@@ -189,7 +189,6 @@ sub writePackageRepo {
   my $file = '/etc/opkg/distfeeds.conf';
   my $disturl = `grep aredn_$repo /etc/opkg/distfeeds.conf | cut -d' ' -f3`;
   chomp($disturl);
-  #`sed -i "s|$disturl|$uciurl|g" $file`;
   system("sed -i 's|$disturl|$uciurl|g' $file");
 }
 # ----- CALLBACKS ----------

--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -2089,8 +2089,6 @@ sub defaultPackageRepos {
   my $url = '';
   #check release
   if ($release =~ /\./) {
-    #print $release . "\n";
-    #stable release
     my @nums = split /\./, $release;
     $urlprefix .= "/releases/" . @nums[0] . "/" . @nums[1] . "/" . $release . "/";
   } else {


### PR DESCRIPTION
Add ability to change the firmware/packages download paths and also change the "internet check" so that if the URL contains ".local.mesh" then it will try to download the needed info from the mesh host.

Tested pretty good, but still review please.