### PR TITLE
bugfix: encode special characters in tunnel comment field

### DIFF
--- a/files/www/cgi-bin/perlfunc.pm
+++ b/files/www/cgi-bin/perlfunc.pm
@@ -200,8 +200,9 @@ sub read_postdata
         $line = fgets(10);
         push(@parse_errors, "not blank: '$line'") unless $line eq "\r\n";
         $line = fgets(1000);
-        if($parm =~ 'description_node') {
+        if(($parm =~ 'description_node') || ($parm =~ '_contact')) {
             $line = substr($line, 0, 210);
+            $line =~ s/"/&quot;/g;
             $line =~ s/'/&apos;/g;
             $line =~ s/</&lt;/g;
             $line =~ s/>/&gt;/g;


### PR DESCRIPTION
catch the tunnel comment field in perlfunc's read_post_data function where certain characters are changed to the html character entity in order to not interfere with the config files.
Tested with all kinds of crazy characters such as: zdsfkh? <!@#$%^&*()> "quote"

Fixes #515