### PR TITLE
aredn: add Mode ether to tunnel interfaces

### DIFF
--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -144,6 +144,7 @@ if ( @tunnels )
   foreach(@tunnels) { push @file, qq("$_" ) }
   push @file, qq(\n{\n);
   push @file, qq(     Ip4Broadcast 255.255.255.255\n);
+  push @file, qq(     Mode \"ether\"\n);
   push @file, qq(}\n);
 }
 


### PR DESCRIPTION
This reduces message forwarding by OLSR. Without this mode
olsr will forward a message backout the same interface it
was received on, presumably due to hidden 802.11n nodes.