### PR TITLE
 aredn: remove node mode configuration notation

### DIFF
--- a/files/www/cgi-bin/status
+++ b/files/www/cgi-bin/status
@@ -260,7 +260,7 @@ if($config eq "mesh" and ! $wifi_disable )
     push @col2, $str;
 }
 
-push @col2, "<th align=right><nobr>firmware version</nobr><br>configuration</th><td><nobr>" . `cat /etc/mesh-release` . "</nobr><br>$config</td>";
+push @col2, "<th align=right><nobr>firmware version</nobr></th><td>" . `cat /etc/mesh-release`. "</td>";
 push @col2, "<th align=right>system time</th><td>" . `date +'%a %b %e %Y<br>%T %Z'` . "</td>";
 
 $uptime = `uptime`;

--- a/files/www/help.html
+++ b/files/www/help.html
@@ -109,8 +109,8 @@ name (if known) of the device accessing this page.
 <p>
 The right column contains the signal strength reading and other attributes of
 your node.  The <b>Signal/Noise/Ratio</b> is a reading of the strongest neighbor Mesh RF signal
-strength (in dBm) from all connected stations, and it is available only when the node is in a Mesh or Client
-configuration.  The <strong>Auto</strong> button will take you to an
+strength (in dBm) from all connected stations.
+The <strong>Auto</strong> button will take you to an
 automatically refreshing display of the current signal strength and an average
 of the last 20 readings. This is provided as an aid to assist in antenna
 aiming. It is of no use until another node is visible, so it is best used a a


### PR DESCRIPTION
In the past nodes could be configured uniquely for
a given mode:  ap, wifi client, mesh. Current behavior
in basic setup no longer has unique modes, rather wireless
cards can be configured in different modes in basic setup
and devices with multiple wireless interfaces can
be setup to use multiple modes at the same time.
   
fixes #533
fixes #535