### PR TITLE
aredn: some LHG based devices stuck in bootloop

### DIFF
--- a/patches/008-add-lhg.patch
+++ b/patches/008-add-lhg.patch
@@ -69,3 +69,15 @@ Index: openwrt/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
  	ATH79_MACH_RB_MAP,			/* Mikrotik RouterBOARD mAP2nD */
  	ATH79_MACH_RB_MAPL,			/* Mikrotik RouterBOARD mAP L-2nD */
  	ATH79_MACH_RB_WAP,			/* Mikrotik RouterBOARD wAP2nD */
+Index: openwrt/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+===================================================================
+--- openwrt.orig/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ openwrt/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -760,6 +760,7 @@ platform_pre_upgrade() {
+ 	rb-952ui-5ac2nd|\
+ 	rb-962uigs-5hact2hnt|\
+ 	rb-lhg-5nd|\
++	rb-lhg-5hpnd|\
+ 	rb-lhg-5hpnd-xl|\
+ 	rb-ldf-5nd|\
+ 	rb-map-2nd|\


### PR DESCRIPTION
add missing board id to sysupgrade pre upgrade steps
for mikrotik NOR based devices