### PR TITLE
Add file size tests to arednMsg

### DIFF
--- a/files/usr/local/bin/aredn_message.sh
+++ b/files/usr/local/bin/aredn_message.sh
@@ -44,21 +44,26 @@ nodename=$(echo "$HOSTNAME" | tr 'A-Z' 'a-z')
 if [ $online = "true" ]
 then
   # fetch node specific message file
-  # nodename=$(echo "$HOSTNAME" | tr 'A-Z' 'a-z')
-  wget -q -O aredn_message -P /tmp http://downloads.arednmesh.org/messages/"${nodename}".txt
-  echo "<strong>&#8611; ${nodename}:</strong>"|cat - /tmp/aredn_message > /tmp/out && mv /tmp/out /tmp/aredn_message
+  wget -q -O aredn_message -P /tmp http://downloads.arednmesh.org/messages/"${nodename}".txt &&
+    [ -s /tmp/aredn_message ] &&
+    echo "<strong>&#8611; ${nodename}:</strong>"|cat - /tmp/aredn_message > /tmp/out &&
+    mv /tmp/out /tmp/aredn_message
   if [ $? -ne 0 ] # no node specific file
   then
     # fetch broadcast message file
-    wget -q -O aredn_message -P /tmp http://downloads.arednmesh.org/messages/all.txt
-    echo "<strong>&#8611; all nodes:</strong>"|cat - /tmp/aredn_message > /tmp/out && mv /tmp/out /tmp/aredn_message
+    wget -q -O aredn_message -P /tmp http://downloads.arednmesh.org/messages/all.txt &&
+    [ -s /tmp/aredn_message ] &&
+    echo "<strong>&#8611; all nodes:</strong>"|cat - /tmp/aredn_message > /tmp/out &&
+    mv /tmp/out /tmp/aredn_message
   else
     # need to append to node file
     wget -q -O aredn_message_all -P /tmp http://downloads.arednmesh.org/messages/all.txt &&
-      echo "<strong>&#8611; all nodes:</strong>"|cat - /tmp/aredn_message_all > /tmp/out && mv /tmp/out /tmp/aredn_message_all
-      echo "<br />" >> /tmp/aredn_message;
-      cat /tmp/aredn_message_all >> /tmp/aredn_message;
-      rm /tmp/aredn_message_all;
+      [ -s /tmp/aredn_message_all ] &&
+      echo "<strong>&#8611; all nodes:</strong>"|cat - /tmp/aredn_message_all > /tmp/out &&
+      mv /tmp/out /tmp/aredn_message_all
+    echo "<br />" >> /tmp/aredn_message
+    cat /tmp/aredn_message_all >> /tmp/aredn_message
+    rm /tmp/aredn_message_all
   fi
 fi
 
@@ -67,20 +72,25 @@ fi
 alertslocalpath=$(uci -q get aredn.@alerts[0].localpath)
 if [ ! -z "$alertslocalpath" ]; then
   # fetch node specific message file
-  wget -q -O local_message -P /tmp "${alertslocalpath}/${nodename}".txt
-  echo "<strong>&#8611; ${nodename}:</strong>"|cat - /tmp/local_message > /tmp/out && mv /tmp/out /tmp/local_message
+  wget -q -O local_message -P /tmp "${alertslocalpath}/${nodename}".txt &&
+    [ -s /tmp/local_message ] &&
+    echo "<strong>&#8611; ${nodename}:</strong>"|cat - /tmp/local_message > /tmp/out &&
+    mv /tmp/out /tmp/local_message
   if [ $? -ne 0 ] # no node specific file
   then
     # fetch broadcast message file
-    wget -q -O local_message -P /tmp "${alertslocalpath}/all.txt"
-    echo "<strong>&#8611; all nodes:</strong>"|cat - /tmp/local_message > /tmp/out && mv /tmp/out /tmp/local_message
+    wget -q -O local_message -P /tmp "${alertslocalpath}/all.txt" &&
+      [ -s /tmp/local_message ] &&
+      echo "<strong>&#8611; all nodes:</strong>"|cat - /tmp/local_message > /tmp/out &&
+      mv /tmp/out /tmp/local_message
   else
     # need to append to node file
     wget -q -O local_message_all -P /tmp "${alertslocalpath}/all.txt" &&
-      echo "<strong>&#8611; all nodes:</strong>"|cat - /tmp/local_message_all > /tmp/out && mv /tmp/out /tmp/local_message_all
-      echo "<br />" >> /tmp/local_message;
-      [ -f /tmp/local_message_all ] &&
-      cat /tmp/local_message_all >> /tmp/local_message &&
-      rm /tmp/local_message_all;
+      [ -s /tmp/local_message_all ] &&
+      echo "<strong>&#8611; all nodes:</strong>"|cat - /tmp/local_message_all > /tmp/out &&
+      mv /tmp/out /tmp/local_message_all
+    echo "<br />" >> /tmp/local_message
+    cat /tmp/local_message_all >> /tmp/local_message &&
+      rm /tmp/local_message_all
   fi
 fi


### PR DESCRIPTION
Add tests for file content to aredn_message.sh
There are cases for my local message repository (and probably for others) where it is normal to expect that an empty message file might exist.  I found that if an empty message file exists, then an empty message prefix/header is displayed.  I added a couple of file size tests to skip processing if the file has no meaningful content.  It may never occur, but I figured it wouldn't hurt to add tests to the AREDN Alerts as well as the Local Alerts.  Tested and verified that empty files in the local message repository will not be processed.