### PR TITLE
aredn: visualize non-propagated and aliased hosts

### DIFF
--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -303,12 +303,13 @@ foreach(`cat $dhcpfile`)
 }
 #aliases need to be added to /etc/hosts or they will not show up on the localnode
 #nor will the services they might offer
+#also add a comment to the hosts file so we can display the aliases differently if needed
 if(-e $aliasfile) {
   foreach(`cat $aliasfile`) {
     next if /^\s*#/;
     next if /^\s*$/;
     ($ip, $host) = split /\s+/, $_;
-    printf HOSTS "$ip\t$host\n";
+    printf HOSTS "$ip\t$host #ALIAS\n";
   }
 }
 print HOSTS "\n";

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -299,7 +299,7 @@ foreach(`cat $dhcpfile`)
   next unless validate_ip_netmask($ip, $cfg{lan_mask});
 
   printf ETHER "$mac\t$ip $noprop\n";
-  printf HOSTS "$ip\t$host\n";
+  printf HOSTS "$ip\t$host $noprop\n";
 }
 #aliases need to be added to /etc/hosts or they will not show up on the localnode
 #nor will the services they might offer

--- a/files/www/aredn.css
+++ b/files/www/aredn.css
@@ -71,7 +71,12 @@ background-color: gainsboro;
 font-size: 12pt;
 width: 40%;
 }
-.muted-text {
-/*  color: #757575; */
+.hidden-hosts {
+  /* light-ish grey */
   color: #595959;
 }
+.aliased-hosts {
+  /* "peru" */
+  color: #CD853F;
+}
+

--- a/files/www/aredn.css
+++ b/files/www/aredn.css
@@ -71,3 +71,7 @@ background-color: gainsboro;
 font-size: 12pt;
 width: 40%;
 }
+.muted-text {
+/*  color: #757575; */
+  color: #595959;
+}

--- a/files/www/black_on_white.css
+++ b/files/www/black_on_white.css
@@ -65,7 +65,11 @@ background-color: whitesmoke;
 font-size: 12pt;
 width: 40%;
 }
-.muted-text {
-/*  color: #757575; */
+.hidden-hosts {
+  /* light-ish grey */
   color: #595959;
+}
+.aliased-hosts {
+  /* "peru" */
+  color: #CD853F;
 }

--- a/files/www/black_on_white.css
+++ b/files/www/black_on_white.css
@@ -65,3 +65,7 @@ background-color: whitesmoke;
 font-size: 12pt;
 width: 40%;
 }
+.muted-text {
+/*  color: #757575; */
+  color: #595959;
+}

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -403,8 +403,8 @@ if(keys %localhosts)
 	if(grep { /$dmzhost/ } @{$localhosts{$ip}{aliases}}) { $aliased = 1; }
         $localpart = $dmzhost =~ s/.local.mesh//r;
 	    if(!$nopropd and !$aliased) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-	    elsif($aliased) { $rows{$host} .= "<tr><td class=aliased-hosts valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-	    else { $rows{$host} .= "<tr><td class=hidden-hosts valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    elsif($aliased) { $rows{$host} .= "<tr><td class=aliased-hosts valign=top title='Aliased Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    else { $rows{$host} .= "<tr><td class=hidden-hosts valign=top title='Non Propagated Host'><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
 	    
 	    $rows{$host} .= "<td colspan=3></td><td>\n";
 	    foreach(sort keys %{$services{$dmzhost}})

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -229,6 +229,7 @@ foreach(`cat /etc/hosts`)
     }
     else { push @{$localhosts{$my_ip}{hosts}}, $name; }
     if($tactical eq "#NOPROP") { push @{$localhosts{$my_ip}{noprops}}, $name; }
+    if($tactical eq "#ALIAS") { push @{$localhosts{$my_ip}{aliases}}, $name; }
 }
 
 # load the olsr hosts file
@@ -395,12 +396,15 @@ if(keys %localhosts)
 	# add locally advertised dmz hosts
 	foreach $dmzhost (@{$localhosts{$ip}{hosts}})
 	{
-        #find non-propagated hosts and make them grey
+        #find non-propagated and aliased hosts and change color
         $nopropd = 0;
+	$aliased = 0;
         if(grep { /$dmzhost/ } @{$localhosts{$ip}{noprops}}) { $nopropd = 1; }
+	if(grep { /$dmzhost/ } @{$localhosts{$ip}{aliases}}) { $aliased = 1; }
         $localpart = $dmzhost =~ s/.local.mesh//r;
-	    if(!$nopropd) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
-	    else { $rows{$host} .= "<tr><td class=muted-text valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    if(!$nopropd and !$aliased) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    elsif($aliased) { $rows{$host} .= "<tr><td class=aliased-hosts valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    else { $rows{$host} .= "<tr><td class=hidden-hosts valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
 	    
 	    $rows{$host} .= "<td colspan=3></td><td>\n";
 	    foreach(sort keys %{$services{$dmzhost}})

--- a/files/www/cgi-bin/mesh
+++ b/files/www/cgi-bin/mesh
@@ -228,6 +228,7 @@ foreach(`cat /etc/hosts`)
 	$localhosts{$ip}{name} = $name;
     }
     else { push @{$localhosts{$my_ip}{hosts}}, $name; }
+    if($tactical eq "#NOPROP") { push @{$localhosts{$my_ip}{noprops}}, $name; }
 }
 
 # load the olsr hosts file
@@ -394,8 +395,13 @@ if(keys %localhosts)
 	# add locally advertised dmz hosts
 	foreach $dmzhost (@{$localhosts{$ip}{hosts}})
 	{
-            $localpart = $dmzhost =~ s/.local.mesh//r;
-	    $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>";
+        #find non-propagated hosts and make them grey
+        $nopropd = 0;
+        if(grep { /$dmzhost/ } @{$localhosts{$ip}{noprops}}) { $nopropd = 1; }
+        $localpart = $dmzhost =~ s/.local.mesh//r;
+	    if(!$nopropd) { $rows{$host} .= "<tr><td valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    else { $rows{$host} .= "<tr><td class=muted-text valign=top><nobr>&nbsp;<img src='/dot.png'>$localpart</nobr></td>"; }
+	    
 	    $rows{$host} .= "<td colspan=3></td><td>\n";
 	    foreach(sort keys %{$services{$dmzhost}})
 	    {

--- a/files/www/loading.css
+++ b/files/www/loading.css
@@ -103,4 +103,7 @@ width: 40%;
 .tun_loading_css_comment {
   font-size: 10pt;
 }
-
+.muted-text {
+/*  color: #757575; */
+  color: #595959;
+}

--- a/files/www/loading.css
+++ b/files/www/loading.css
@@ -103,7 +103,11 @@ width: 40%;
 .tun_loading_css_comment {
   font-size: 10pt;
 }
-.muted-text {
-/*  color: #757575; */
+.hidden-hosts {
+  /* light-ish grey */
   color: #595959;
+}
+.aliased-hosts {
+  /* "peru" */
+  color: #CD853F;
 }

--- a/files/www/red_on_black.css
+++ b/files/www/red_on_black.css
@@ -65,3 +65,7 @@ background-color: dimgrey;
 font-size: 12pt;
 width: 40%;
 }
+.muted-text {
+/*  color: #757575; */
+  color: #595959;
+}

--- a/files/www/red_on_black.css
+++ b/files/www/red_on_black.css
@@ -65,7 +65,11 @@ background-color: dimgrey;
 font-size: 12pt;
 width: 40%;
 }
-.muted-text {
-/*  color: #757575; */
-  color: #595959;
+.hidden-hosts {
+  /* "silver" */
+  color: #c0c0c0
+}
+.aliased-hosts {
+  /* tan */
+  color: #D2B48C;
 }

--- a/files/www/white_on_black.css
+++ b/files/www/white_on_black.css
@@ -67,7 +67,11 @@ background-color: dimgrey;
 font-size: 12pt;
 width: 40%;
 }
-.muted-text {
-/*  color: #757575; */
-  color: #595959;
+.hidden-hosts {
+  /* "silver" */
+  color: #c0c0c0;
+}
+.aliased-hosts {
+  /* tan */
+  color: #D2B48C;
 }

--- a/files/www/white_on_black.css
+++ b/files/www/white_on_black.css
@@ -67,3 +67,7 @@ background-color: dimgrey;
 font-size: 12pt;
 width: 40%;
 }
+.muted-text {
+/*  color: #757575; */
+  color: #595959;
+}

--- a/files/www/yellow_on_black.css
+++ b/files/www/yellow_on_black.css
@@ -65,3 +65,7 @@ background-color: dimgrey;
 font-size: 12pt;
 width: 40%;
 }
+.muted-text {
+/*  color: #757575; */
+  color: #595959;
+}

--- a/files/www/yellow_on_black.css
+++ b/files/www/yellow_on_black.css
@@ -65,7 +65,11 @@ background-color: dimgrey;
 font-size: 12pt;
 width: 40%;
 }
-.muted-text {
-/*  color: #757575; */
-  color: #595959;
+.hidden-hosts {
+  /* "silver" */
+  color: #c0c0c0
+}
+.aliased-hosts {
+  /* tan */
+  color: #D2B48C;
 }


### PR DESCRIPTION
Show aliased and non propagated hosts differently on the mesh list.  
Only effects the localnode where the hosts are hidden/aliased.  
Just tries to provide a way for the node admin to easily visualize the setup from the `mesh` page.