### PR TITLE
aredn: enhancement: Nat mode aliases

### DIFF
--- a/files/etc/arednsysupgrade.conf
+++ b/files/etc/arednsysupgrade.conf
@@ -7,7 +7,8 @@
 /etc/config.mesh/_setup.ports.nat
 /etc/config.mesh/_setup.services.dmz
 /etc/config.mesh/_setup.services.nat
-/etc/config.mesh/aliases
+/etc/config.mesh/aliases.dmz
+/etc/config.mesh/aliases.nat
 /etc/config.mesh/vtun
 /etc/config.mesh/aredn
 /etc/dropbear/dropbear_dss_host_key

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -195,7 +195,15 @@ $dhcpfile .= ($cfg{dmz_mode} ? ".dmz" : ".nat");
 $aliasfile = "/etc/config.mesh/aliases";
 $aliasfile .= ($cfg{dmz_mode} ? ".dmz" : ".nat");
 
-
+#check for old aliases file, copy it to .dmz and create symlink
+#just in case anyone is already using the file for some script or something
+unless(-l "/etc/config.mesh/aliases") {
+  if(-f "/etc/config.mesh/aliases") {
+    system "cat /etc/config.mesh/aliases > /etc/config.mesh/aliases.dmz";
+    system "rm /etc/config.mesh/aliases";
+    system "cd /etc/config.mesh ; ln -s aliases.dmz aliases";
+  } else { system "cd /etc/config.mesh ; touch aliases.dmz ; ln -s aliases.dmz aliases"; }
+}
 # basic configuration
 
 if($do_basic)

--- a/files/usr/local/bin/node-setup
+++ b/files/usr/local/bin/node-setup
@@ -193,6 +193,7 @@ $dhcpfile  = "/etc/config.mesh/_setup.dhcp";
 $portfile .= ($cfg{dmz_mode} ? ".dmz" : ".nat");
 $dhcpfile .= ($cfg{dmz_mode} ? ".dmz" : ".nat");
 $aliasfile = "/etc/config.mesh/aliases";
+$aliasfile .= ($cfg{dmz_mode} ? ".dmz" : ".nat");
 
 
 # basic configuration

--- a/files/usr/local/bin/olsrd-config
+++ b/files/usr/local/bin/olsrd-config
@@ -68,7 +68,7 @@ if(-f "/etc/config/dmz-mode")
 {
   # add DNS aliases first
   # (see above comment about "tactical" names)
-  foreach(`cat /etc/config.mesh/aliases`) {
+  foreach(`cat /etc/config.mesh/aliases.dmz`) {
     next unless ($ip, $host) = split ' ', $_;
     push @hosts, qq("$ip" "$host");
   }

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -97,9 +97,6 @@ $dhcpfile .= $suffix;
 $servfile .= $suffix;
 $aliasfile .= $suffix;
 
-#find old alias file and move it to dmz file
-if(-e "/etc/config.mesh/aliases") { system "cat /etc/config.mesh/aliases > /etc/config.mesh/aliases.dmz ; rm /etc/config.mesh/aliases"; }
-
 # if a reset or a first time page load
 # read the data from the config files
 if($parms{button_reset} or not $parms{reload})
@@ -742,8 +739,14 @@ else
     print "</tr></table></td></tr>\n";
     print "<tr><td>&nbsp;</td></tr>\n";
     print "<tr><td><hr></td></tr>\n";
+    print "</table><table width=790>\n";
     print "<tr><td align=center>\n";
     &print_reservations();
+    print "</td>\n";
+    print "<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>\n";
+    print "<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>\n";
+    print "<td align=center valign=top>\n";
+    &print_aliases();
     print "</td></tr>\n";
 }
 
@@ -882,7 +885,10 @@ sub print_reservations
 {
     print "<table cellpadding=0 cellspacing=0><tr><th colspan=4>DHCP Address Reservations</th></tr>\n";
     print "<tr><td colspan=4 height=5></td></tr>\n";
-    print "<tr><td align=center>Hostname</td><td align=center>IP Address</td><td align=center>MAC Address</td><td align=center style='font-size:10px;'>Do Not<br>Propagate</td><td></td></tr>\n";
+    print "<tr><td align=center>Hostname</td><td align=center>IP Address</td><td align=center>MAC Address</td>";
+    if($dmz_mode) {
+      print "<td align=center style='font-size:10px;'>Do Not<br>Propagate</td><td></td></tr>\n";
+    } else { print "<td></td><td></td></tr>\n"; }
     print "<tr><td colspan=4 height=5></td></tr>\n";
 
     for($i = 1, @list = (); $i <= $parms{dhcp_num}; ++$i) { push @list, $i }
@@ -912,11 +918,14 @@ sub print_reservations
 	print "</select></td>\n";
 
 	print "<td><input type=text name=dhcp${val}_mac value='$mac' size=16></td>\n";
-        if ($noprop eq "#NOPROP") {
-          print "<td align=center><input type=checkbox id=dhcp${val}_noprop name=dhcp${val}_noprop value='#NOPROP' checked></td>\n";
-        }else {
-          print "<td align=center><input type=checkbox id=dhcp${val}_noprop name=dhcp${val}_noprop value='#NOPROP'></td>\n";
-        }
+    if($dmz_mode) {
+      if ($noprop eq "#NOPROP") {
+        print "<td align=center><input type=checkbox id=dhcp${val}_noprop name=dhcp${val}_noprop value='#NOPROP' checked></td>\n";
+      }else {
+        print "<td align=center><input type=checkbox id=dhcp${val}_noprop name=dhcp${val}_noprop value='#NOPROP'></td>\n";
+      }
+    }else { print "<td></td>\n"; }
+    
 	print "<td><nobr>&nbsp;<input type=submit name=";
 
 	if($val eq "_add") { print "dhcp_add       value=Add title='Add this as a DHCP reservation'" }

--- a/files/www/cgi-bin/ports
+++ b/files/www/cgi-bin/ports
@@ -95,7 +95,10 @@ my $suffix = $dmz_mode ? ".dmz" : ".nat";
 $portfile .= $suffix;
 $dhcpfile .= $suffix;
 $servfile .= $suffix;
-#do not need mesh aliases in anything other than "dmz_mode"
+$aliasfile .= $suffix;
+
+#find old alias file and move it to dmz file
+if(-e "/etc/config.mesh/aliases") { system "cat /etc/config.mesh/aliases > /etc/config.mesh/aliases.dmz ; rm /etc/config.mesh/aliases"; }
 
 # if a reset or a first time page load
 # read the data from the config files


### PR DESCRIPTION
Added aliases in NAT Mode.  
NAT Mode aliases work much differently than normal DMZ Mode aliases, they are by default _NOT_ propagated out across the mesh, and cannot be made to do so, they _ONLY_ effect the node local LAN.  
You _CANNOT_ use an alias name in a service listing or a port forwarding rule, it's just not possible due to how `iptables` works.  
You _will_ be able to set an alternate hostname for any host on the nodes' LAN however.  
A host named `CBY45-DELLLAPTOP` can also be known as `wxc-shack-laptop`. It may make remembering which host is which a bit easier.  
  
Also snuck in a change to hide the "Do Not Propagate" checkbox while in NAT Mode.