### PR TITLE
ath79: Enable the LNA for ALL for the TP-Link CPExxx AR9344 Devices

### DIFF
--- a/patches/001-ath79-cpexxx_lna.patch
+++ b/patches/001-ath79-cpexxx_lna.patch
@@ -1,0 +1,47 @@
+--- a/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
++++ b/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
+@@ -110,3 +110,20 @@
+ 
+ 	mtd-mac-address = <&info 0x8>;
+ };
++
++&gpio { 
++ 	gpio_ext_lna0 { 
++ 		gpio-hog; 
++ 		gpios = <18 GPIO_ACTIVE_HIGH>; 
++ 		output-high; 
++ 		line-name = "tp-link:ext:lna0"; 
++ 	}; 
++ 
++ 
++ 	gpio_ext_lna1 { 
++ 		gpio-hog; 
++ 		gpios = <19 GPIO_ACTIVE_HIGH>; 
++ 		output-high; 
++ 		line-name = "tp-link:ext:lna1"; 
++ 	}; 
++}; 
+--- a/target/linux/ath79/dts/ar9344_tplink_cpe_2port.dtsi
++++ b/target/linux/ath79/dts/ar9344_tplink_cpe_2port.dtsi
+@@ -44,21 +44,6 @@
+ 	};
+ };
+ 
+-&gpio {
+-	gpio_ext_lna0 {
+-		gpio-hog;
+-		gpios = <18 0>;
+-		output-high;
+-		line-name = "tp-link:ext:lna0";
+-	};
+-
+-	gpio_ext_lna1 {
+-		gpio-hog;
+-		gpios = <19 0>;
+-		output-high;
+-		line-name = "tp-link:ext:lna1";
+-	};
+-};
+ 
+ &eth1 {
+ 	status = "okay";

--- a/patches/series
+++ b/patches/series
@@ -17,6 +17,7 @@
 001-add_support_for_TP-Link_CPE510_v3.20.patch
 001-ath79-cpe220v3-sysupgrade-supported.patch
 001_cpe220v3_bugfix.patch
+001-ath79-cpexxx_lna.patch
 004-add-lhg-5hpnd-xl.patch
 004-add-ldf-5nd.patch
 005-add-haplite-new-model.patch


### PR DESCRIPTION


	This should improve the Power Levels for the 1 Port Devices as it was not enabled for them.